### PR TITLE
Add the /whoami endpoint for the frontend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ watchdog                          # Watch for files change
 pydantic
 #fastobo~=0.11.1
 aiosql
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.6
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1  # CanDIG logging wrapper

--- a/schema.yml
+++ b/schema.yml
@@ -578,7 +578,20 @@ paths:
           $ref: "#/components/responses/5xxServerError"
       tags:
         - Persons
-
+  /whoami:
+    get:
+      summary: Determine the current user's user key (usually their email)
+      description: Determine the current user's user key (usually their email)
+      operationId: query_operations.whoami
+      responses:
+        200:
+          description: Person deleted successfully
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/WhoAmIBody"
+        5XX:
+          $ref: "#/components/responses/5xxServerError"
 components:
   responses:
     400BadRequestError:
@@ -1622,3 +1635,9 @@ components:
         - content_type
         - size
         - message
+    WhoAmIBody:
+      type: object
+      properties:
+        key:
+          type: string
+          description: User's key, usually their email

--- a/schema.yml
+++ b/schema.yml
@@ -585,7 +585,7 @@ paths:
       operationId: query_operations.whoami
       responses:
         200:
-          description: Person deleted successfully
+          description: Person ID retrieved successfully
           content:
             application/json:
               schema:

--- a/src/api/query_operations.py
+++ b/src/api/query_operations.py
@@ -3,12 +3,14 @@ API query operations like service info, file upload and status tracking...
 """
 
 import json
+import connexion
 import os
 import secrets
 import shutil
 import tempfile
 from datetime import datetime, timezone
 
+from authx.auth import get_user_id
 from candigv2_logging.logging import CanDIGLogger
 from connexion.exceptions import ProblemException
 
@@ -110,3 +112,11 @@ async def get_upload_status(queue_id: str):
                 "message": f"Unable to read status for job {queue_id}",
             }
         }, 500
+
+async def whoami():
+    """
+    Determine the user key of the currently logged in user
+    NB: This should probably not be in candig-api, and should be moved out when we can
+    """
+    OPA_URL = os.getenv("OPA_URL", f"http://localhost:8181")
+    return { 'key': get_user_id(connexion.request, opa_url = OPA_URL) }, 200

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -542,7 +542,7 @@ async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=R
     count_ids = 0
     if qparams.query.pagination.limit == 0:
         qparams.query.pagination.limit = MAX_LIMIT
-    if qparams.query.filters:
+    if qparams.query.filters and len(qparams.query.filters) > 0 and len(qparams.query.filters[0]) > 0:
         # NB: qparams.query.filters is a list, whereas we need it to be a dict?
         listIds, count_ids = await filters(qparams.query.filters[0],
                         offset=qparams.query.pagination.skip,


### PR DESCRIPTION
# Ticket(s)

- [DIG-2169](https://candig.atlassian.net/browse/DIG-2169)

# Description
This replaces query's old /whoami endpoint, which allows the frontend to know who it is currently logged in as without allowing it to inspect its own cookies.

# To test
/whoami should respond to queries with:
```
curl candig.docker.internal:5080/candig-api/v1/whoami -H "Authorization: Bearer $TOKEN"
{"key": "site_admin@test.ca"}
```


## Types of Change(s)

- [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

If breaking, Which other services does it affect?

- [ ] authx
- [ ] data-portal
- [ ] ingest
- [ ] clinical ETL
- [ ] federation
- [ ] htsget-app
- [ ] katsu
- [ ] CanDIG OPA
- [ ] Query

<!--- If a breaking change, describe the impact the PR will have on the services selected above --->

## Has it been tested for:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] Prettier linter doesn't return errors
- [ ] Locally tested
  - [ ] using stable release
  - [ ] using develop branches
- [ ] Dev server tested
- [ ] Production tested when merging into stable/production branch


[DIG-2169]: https://candig.atlassian.net/browse/DIG-2169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ