### PR TITLE
DIG-2143: Move authz to candig-api

### DIFF
--- a/authz-schema.yml
+++ b/authz-schema.yml
@@ -1,0 +1,602 @@
+openapi: 3.0.0
+info:
+  version: v1.0.0
+  title: 'CanDIGv3 Authorization Service'
+  description: 'API for managing authorization in CanDIG'
+servers:
+  - url: /v1/authz
+paths:
+  /service-info:
+    get:
+      summary: Retrieve information about this service
+      description: Returns information about the ingest service
+      operationId: authz_operations.get_service_info
+      responses:
+        200:
+          description: Retrieve info about the ingest service
+          content:
+            application/json:
+              schema:
+                type: object
+  /s3-credential:
+    post:
+      summary: Add credentials for an S3 bucket
+      description: Add credentials for an S3 bucket
+      operationId: src.api.authz_operations.add_s3_credential
+      requestBody:
+        $ref: '#/components/requestBodies/S3CredentialRequest'
+      responses:
+          200:
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/S3Credential'
+  /s3-credential/endpoint/{endpoint_id}/bucket/{bucket_id}:
+    parameters:
+      - in: path
+        name: endpoint_id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: bucket_id
+        schema:
+          type: string
+        required: true
+    get:
+      summary: get credentials for an S3 bucket
+      description: get credentials for an S3 bucket
+      operationId: src.api.authz_operations.get_s3_credential
+      responses:
+          200:
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/S3Credential"
+    delete:
+      summary: delete credentials for an S3 bucket
+      description: delete credentials for an S3 bucket
+      operationId: src.api.authz_operations.delete_s3_credential
+      responses:
+          200:
+            description: Success
+            content:
+              application/json:
+                schema:
+                  type: object
+
+  /site-role/{role_type}:
+    parameters:
+      - in: path
+        name: role_type
+        description: Defined site roles for this CanDIG node. By default, admin and curator are defined.
+        schema:
+          type: string
+        required: true
+    get:
+      summary: List users in role_type
+      description: List users in role_type
+      operationId: src.api.authz_operations.list_role
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /site-role/{role_type}/user_id/{user_id}:
+    parameters:
+      - in: path
+        name: role_type
+        description: Defined site roles for this CanDIG node. By default, admin and curator are defined.
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: user_id
+        schema:
+          type: string
+        required: true
+    get:
+      summary: Is user in this role?
+      description: Is user in this role?
+      operationId: src.api.authz_operations.is_user_in_role
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: boolean
+    post:
+      summary: Assign user to role
+      description: Assign user to role
+      operationId: src.api.authz_operations.add_user_to_role
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+    delete:
+      summary: Remove user from role
+      description: Remove user from role
+      operationId: src.api.authz_operations.remove_user_from_role
+      responses:
+        200:
+          description: Success
+        404:
+          description: User not found in role
+        405:
+          description: Can't remove user from role
+  /program:
+    post:
+      summary: Add authorization information for a new program (or overwrite authorization information for an existing program).
+      description: Add authorization information for a new program (or overwrite authorization information for an existing program). Information in the request body replaces any existing information for the program.
+      operationId: src.api.authz_operations.add_program
+      requestBody:
+        $ref: '#/components/requestBodies/ProgramIngestRequest'
+      responses:
+          200:
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: "#/components/schemas/Program"
+    get:
+      summary: List registered programs
+      description: List programs authorized on server
+      operationId: src.api.authz_operations.list_programs
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+  /program/{program_id}:
+    parameters:
+      - in: path
+        name: program_id
+        schema:
+          type: string
+        required: true
+    get:
+      summary: Get authorization information for a program
+      description: Get authorization information for a program
+      operationId: src.api.authz_operations.get_program
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Program"
+    delete:
+      description: Delete a program
+      operationId: src.api.authz_operations.remove_program
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+  /program/{program_id}/dac_authorization:
+    parameters:
+      - in: path
+        name: program_id
+        schema:
+          type: string
+        required: true
+    get:
+      summary: Get a program's DAC authorizations
+      description: Get a program's DAC authorizations
+      operationId: src.api.authz_operations.get_program_dacs
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+  /user/pending/request:
+    post:
+      summary: Add pending user
+      description: Add the user specified in the Bearer jwt to the pending users list
+      operationId: src.api.authz_operations.add_pending_user
+      responses:
+        200:
+          description: Success
+  /user/pending:
+    get:
+      summary: List pending users
+      description: List pending users for authorization
+      operationId: src.api.authz_operations.list_pending_users
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/UserInfo"
+    post:
+      summary: Approve pending users
+      description: Approve bulk pending users for CanDIG access
+      operationId: src.api.authz_operations.approve_pending_users
+      requestBody:
+        $ref: '#/components/requestBodies/ApprovePendingUserRequest'
+      responses:
+        200:
+          description: Success
+    delete:
+      summary: Delete pending users
+      description: Clear pending users for CanDIG access
+      operationId: src.api.authz_operations.clear_pending_users
+      responses:
+        200:
+          description: Success
+  /user/pending/{user_id}:
+    parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: string
+        required: true
+        description: The user ID to check. If "me", return information about the requesting user
+    get:
+      summary: Is a user pending?
+      description: Is a user pending?
+      operationId: src.api.authz_operations.is_user_pending
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: boolean
+    post:
+      summary: Approve pending user
+      description: Approve a pending user for CanDIG access
+      operationId: src.api.authz_operations.approve_pending_user
+      responses:
+        200:
+          description: Success
+    delete:
+      summary: Reject pending user
+      description: Reject a pending user for CanDIG access
+      operationId: src.api.authz_operations.reject_pending_user
+      responses:
+        200:
+          description: Success
+  /user/preapproved:
+    get:
+      summary: List preapproved users
+      description: List preapproved users for authorization
+      operationId: src.api.authz_operations.list_preapproved_users
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/UserInfo"
+    post:
+      summary: Add preapproved users
+      description: Add bulk preapproved users for CanDIG access
+      operationId: src.api.authz_operations.add_preapproved_users
+      requestBody:
+        $ref: '#/components/requestBodies/AddPreapprovedUserRequest'
+      responses:
+        200:
+          description: Success
+    delete:
+      summary: Delete preapproved users
+      description: Clear preapproved users for CanDIG access
+      operationId: src.api.authz_operations.clear_preapproved_users
+      responses:
+        200:
+          description: Success
+  /user/preapproved/{user_id}:
+    parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: string
+        required: true
+    get:
+      summary: Check preapproved list for user
+      description: Check preapproved list for user
+      operationId: src.api.authz_operations.get_preapproved_user
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserInfo"
+        404:
+          description: User not found
+    post:
+      summary: Add preapproved user
+      description: Add a preapproved user for CanDIG access
+      operationId: src.api.authz_operations.add_preapproved_user
+      responses:
+        200:
+          description: Success
+    delete:
+      summary: Remove preapproved user
+      description: Remove a preapproved user for CanDIG access
+      operationId: src.api.authz_operations.remove_preapproved_user
+      responses:
+        200:
+          description: Success
+  /user/{user_id}:
+    parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: string
+        required: true
+        description: The user ID to check. If "me", return information about the requesting user
+    get:
+      summary: List authorization information about a user
+      description: List authorization information about a user
+      operationId: src.api.authz_operations.list_authz_for_user
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/UserAuthorization"
+        403:
+          description: User not found
+    delete:
+      summary: Revoke CanDIG authorization for a user
+      description: Revoke CanDIG authorization for a user
+      operationId: src.api.authz_operations.revoke_authz_for_user
+      responses:
+        200:
+          description: Success
+  /user/{user_id}/dac_authorization:
+    parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: string
+        required: true
+    post:
+      summary: Authorize a program for a user
+      description: Authorize a program for a user (or update a program auth for a user)
+      operationId: src.api.authz_operations.add_dac_authz_for_user
+      requestBody:
+        $ref: '#/components/requestBodies/DACAuthorizationRequest'
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserAuthorization'
+  /user/{user_id}/dac_authorization/{program_id}:
+    parameters:
+      - in: path
+        name: user_id
+        schema:
+          type: string
+        required: true
+      - in: path
+        name: program_id
+        schema:
+          type: string
+        required: true
+    get:
+      summary: Get a DAC authorization for a user
+      description: Remove a DAC authorization for a user
+      operationId: src.api.authz_operations.get_dac_authz_for_user
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DACAuthorization"
+    delete:
+      summary: Remove a DAC authorization for a user
+      description: Remove a DAC authorization for a user
+      operationId: src.api.authz_operations.remove_dac_authz_for_user
+      responses:
+        200:
+          description: Success
+  /get-token:
+    get:
+      summary: Get a new token
+      description: Exchange the refresh token implicit in the request for a new one
+      operationId: src.api.authz_operations.get_token
+      responses:
+        200:
+          description: Success
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+components:
+  requestBodies:
+    S3CredentialRequest:
+      content:
+        'application/json':
+          schema:
+            $ref: "#/components/schemas/S3Credential"
+    ProgramIngestRequest:
+      content:
+        'application/json':
+          schema:
+            $ref: "#/components/schemas/Program"
+    ApprovePendingUserRequest:
+      content:
+        'application/json':
+          schema:
+            type: array
+            items:
+              type: string
+    AddPreapprovedUserRequest:
+      content:
+        'application/json':
+          schema:
+            type: array
+            items:
+              type: string
+    RoleTypeRequest:
+      content:
+        'application/json':
+          schema:
+            type: array
+            items:
+              type: string
+    DACAuthorizationRequest:
+      content:
+        'application/json':
+          schema:
+            oneOf:
+              - $ref: "#/components/schemas/DACAuthorization"
+              - type: array
+                items:
+                  $ref: "#/components/schemas/DACAuthorization"
+  schemas:
+    S3Credential:
+      type: object
+      properties:
+        endpoint:
+          type: string
+          description: URL to the endpoint
+          pattern: (https*):\/\/(.+)
+          example: http://candig.docker.internal:9000
+        bucket:
+          type: string
+          description: name of the bucket
+        access_key:
+          type: string
+          description: access key for the bucket
+        secret_key:
+          type: string
+          description: secret key for the bucket
+      required:
+        - endpoint
+        - bucket
+        - access_key
+        - secret_key
+    Program:
+      type: object
+      description: Describes a program
+      properties:
+        program_id:
+          type: string
+          description: name of the program
+        program_curators:
+          type: array
+          description: list of users who are program curators for this program
+          items:
+            type: string
+        team_members:
+          type: array
+          description: list of users who are original researchers for this program
+          items:
+            type: string
+        creation_date:
+          type: string
+          pattern: '^\d{4}-\d{2}-\d{2}$'
+          description: date program was created, for embargo purposes. This may or may not be the date of ingest.
+      required:
+        - program_id
+        - program_curators
+        - team_members
+    DACAuthorization:
+      type: object
+      properties:
+        program_id:
+          type: string
+        start_date:
+          type: string
+          pattern: '^\d{4}-\d{2}-\d{2}$'
+        end_date:
+          type: string
+          pattern: '^\d{4}-\d{2}-\d{2}$'
+      required:
+        - program_id
+        - start_date
+        - end_date
+    UserInfo:
+      type: object
+      description: describes an authenticated user
+      properties:
+        sample_jwt:
+          type: string
+          description: a sample jwt for this user from their IDP
+        user_name:
+          type: string
+          description: unique id of user, from CANDIG_USER_KEY field
+      required:
+        - user_name
+    UserAuthorization:
+      type: object
+      description: describes an authorized user and the programs the user is authorized to view
+      properties:
+        userinfo:
+          $ref: "#/components/schemas/UserInfo"
+        site_roles:
+          type: array
+          items:
+            type: string
+        program_authorizations:
+          type: object
+          properties:
+            team_member:
+              type: array
+              description: list of programs that the user is a team member of
+              items:
+                type: string
+            program_curator:
+              type: array
+              description: list of programs that the user is a curator of
+              items:
+                type: string
+            dac_authorizations:
+              type: array
+              description: list of programs that this user is authorized to view
+              items:
+                $ref: "#/components/schemas/DACAuthorization"
+    Action:
+      type: object
+      description: an action for which authorization is requested
+      properties:
+        endpoint:
+          description: path to an endpoint that performs the requested action. Should be in the form of a GoLang regex, e.g. `/users/?.*`
+          type: string
+        method:
+          description: the operation to be performed.
+          type: string
+          enum:
+            - GET
+            - POST
+            - UPDATE
+            - DELETE
+      required:
+        - endpoint
+        - method

--- a/authz.json
+++ b/authz.json
@@ -1,0 +1,74 @@
+{
+    "read": {
+        "get": [
+            "/v1/datasets",
+            "/v1/datasets/?.*",
+            "/v1/datasets/?.*/info",
+            "/v1/datasets/?.*/statistics",
+            "/v1/datasets/?.*/persons",
+            "/v1/datasets/?.*/persons/?.*",
+            "/v1/beacon/datasets/?.*",
+            "/htsget/v1/variants/?.*",
+            "/htsget/v1/variants/search",
+            "/htsget/v1/reads/?.*",
+            "/htsget/v1/samples/?.*",
+            "/ga4gh/drs/v1/objects/?.*",
+            "/ga4gh/drs/v1/programs/?.*",
+            "/ga4gh/drs/v1/programs/?.*/status",
+            "/beacon/v2/g_variants/?.*"
+        ],
+        "post": [
+            "/v1/beacon/?.*",
+            "/htsget/v1/variants/search",
+            "/htsget/v1/samples",
+            "/beacon/v2/g_variants"
+        ]
+    },
+    "curate": {
+        "get": [
+            "/v1/authz/get-token",
+            "/v1/authz/program",
+            "/v1/authz/program/?.*",
+            "/v1/authz/program/?.*/dac_authorization",
+            "/v1/authz/s3-credential/?.*",
+            "/v1/authz/site-role/?.*",
+            "/v1/authz/user/?.*",
+            "/ga4gh/drs/v1/objects/?.*",
+            "/ga4gh/drs/v1/programs/?.*",
+            "/ga4gh/drs/v1/programs/?.*/status",
+            "/htsget/v1/variants/?.*",
+            "/htsget/v1/variants/search",
+            "/htsget/v1/reads/?.*",
+            "/htsget/v1/samples/?.*",
+            "/htsget/v1/?.*/index",
+            "/htsget/v1/?.*/verify",
+            "/beacon/v2/g_variants/?.*"
+        ],
+        "post": [
+            "/v1/authz/program",
+            "/v1/authz/s3-credential",
+            "/v1/authz/site-role/?.*",
+            "/v1/authz/user/?.*",
+            "/v1/datasets/upload",
+            "/ga4gh/drs/v1/?.*",
+            "/htsget/v1/variants/search",
+            "/htsget/v1/samples",
+            "/beacon/v2/g_variants"
+        ],
+        "put": [
+            "/v1/datasets",
+            "/v1/datasets/?.*"
+        ],
+        "patch": [
+            "/v1/datasets/?.*"
+        ],
+        "delete": [
+            "/v1/authz/program/?.*",
+            "/v1/authz/s3-credential/?.*",
+            "/v1/authz/site-role/?.*",
+            "/v1/authz/user/?.*",
+            "/v1/datasets/?.*",
+            "/ga4gh/drs/v1/?.*"
+        ]
+    }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ pydantic
 #fastobo~=0.11.1
 aiosql
 candigv2-logging@git+https://github.com/CanDIG/candigv2-logging.git@v1.0.1  # CanDIG logging wrapper
+candigv2-authx@git+https://github.com/CanDIG/candigv2-authx.git@v2.8.7

--- a/schema.yml
+++ b/schema.yml
@@ -680,8 +680,8 @@ components:
           required:
             - error
             - message
-      required:
-        - query
+      # required:
+      #   - query
 
     BadRequestError:
       allOf:

--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -1,0 +1,359 @@
+import authx.auth
+import os
+import re
+import json
+import urllib
+
+
+def is_default_site_admin_set():
+    default_site_admin = os.getenv("DEFAULT_SITE_ADMIN_USER", "")
+    if default_site_admin != "":
+        result, status_code = authx.auth.get_service_store_secret("opa", key=f"site_roles")
+        if status_code == 200:
+            if 'admin' in result['site_roles']:
+                return default_site_admin in ",".join(result['site_roles']['admin'])
+        raise Exception(f"ERROR: Unable to list site administrators {result} {status_code}")
+    return False
+
+
+def get_refresh_token(token):
+    client_secret = authx.auth.get_service_store_secret(service="keycloak", key="client-secret")
+    return authx.auth.get_oauth_response(
+        client_secret = client_secret,
+        refresh_token=token
+        )
+
+
+######
+# Programs
+######
+
+def get_program(program_id):
+    """
+    Returns a ProgramAuthorization for the program_id
+    Authorized only if the service requesting it is allowed to see Opa's vault secrets.
+    """
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"programs/{program_id}")
+    if status_code < 300:
+        return response[program_id], status_code
+    return {"message": f"{program_id} not found"}, status_code
+
+
+def list_programs():
+    progs_response, status_code = authx.auth.get_service_store_secret("opa", key="programs")
+    if status_code == 200:
+        return progs_response['programs'], status_code
+    return progs_response, status_code
+
+
+def add_program(program_auth):
+    """
+    Creates or updates a ProgramAuthorization in Opa's vault service store for the program_id.
+    Authorized only if the requesting service is allowed to write Opa's vault secrets.
+    """
+    program_id = program_auth["program_id"]
+    response, status_code = get_program(program_id)
+    if status_code < 300 or status_code == 404:
+        # create or update the program itself
+        program_auth["program_curators"] = list(map(lambda x: x.lower(), program_auth["program_curators"]))
+        program_auth["team_members"] = list(map(lambda x: x.lower(), program_auth["team_members"]))
+
+        if "date_created" not in program_auth:
+            from datetime import datetime
+            program_auth["date_created"] = datetime.today().strftime('%Y-%m-%d')
+        response, status_code = authx.auth.set_service_store_secret("opa", key=f"programs/{program_id}", value=json.dumps({program_id: program_auth}))
+        if status_code < 300:
+            # update the values for the program list
+            response2, status_code = authx.auth.get_service_store_secret("opa", key="programs")
+
+            if status_code == 200:
+                # check to see if it's already here:
+                if program_id not in response2['programs']:
+                    response2['programs'].append(program_id)
+            else:
+                response2 = {'programs': [program_id]}
+            response2, status_code = authx.auth.set_service_store_secret("opa", key="programs", value=json.dumps(response2))
+            return response, status_code
+
+    # add the users to the preapproved user list
+    for user_id in program_auth["team_members"]:
+        # if the user isn't already approved, make sure they will be:
+        response, status_code = add_preapproved_user(user_id)
+    for user_id in program_auth["program_curators"]:
+        # if the user isn't already approved, make sure they will be:
+        response, status_code = add_preapproved_user(user_id)
+
+    return {"message": f"{program_id} not added"}, status_code
+
+
+def remove_program(program_id):
+    """
+    Removes the ProgramAuthorization in Opa's vault service store for the program_id.
+    Authorized only if the requesting service is allowed to write Opa's vault service store.
+    """
+    response, status_code = get_program(program_id)
+    if status_code == 404:
+        return response, status_code
+    if status_code < 300:
+        # create or update the program itself
+        response, status_code = authx.auth.delete_service_store_secret("opa", key=f"programs/{program_id}")
+
+        # update the values for the program list
+        response, status_code = authx.auth.get_service_store_secret("opa", key="programs")
+
+        if status_code == 200:
+            # check to see if it's here:
+            if program_id in response['programs']:
+                response['programs'].remove(program_id)
+                response, status_code = authx.auth.set_service_store_secret("opa", key="programs", value=json.dumps(response))
+
+        return {"success": f"{program_id} removed"}, status_code
+    return {"message": f"{program_id} not removed"}, status_code
+
+
+#####
+# Site roles
+#####
+
+def list_role_types():
+    result, status_code = authx.auth.get_service_store_secret("opa", key=f"site_roles")
+    if status_code == 200:
+        return list(result['site_roles'].keys()), 200
+    return result, status_code
+
+
+def get_role_type(role_type):
+    result, status_code = authx.auth.get_service_store_secret("opa", key=f"site_roles")
+    if status_code == 200:
+        if role_type in list(result['site_roles'].keys()):
+            return {role_type: result['site_roles'][role_type]}, 200
+        return {"error": f"role type {role_type} does not exist"}, 404
+    return result, status_code
+
+
+def set_role_type(role_type, members):
+    result, status_code = authx.auth.get_service_store_secret("opa", key=f"site_roles")
+    if status_code == 200:
+        if role_type in result['site_roles']:
+            members = list(map(lambda x: x.lower(), members))
+            for user_id in members:
+                # if the user isn't already approved, make sure they will be:
+                response, status_code = add_preapproved_user(user_id)
+
+            result['site_roles'][role_type] = members
+            result, status_code = authx.auth.set_service_store_secret("opa", key=f"site_roles", value=json.dumps(result))
+            if status_code == 200:
+                return result['site_roles'][role_type], status_code
+        return {"error": f"role type {role_type} does not exist"}, 404
+    return result, status_code
+
+
+#####
+# DAC authorization for users
+#####
+
+def write_user(user_dict):
+    safe_name = urllib.parse.quote_plus(user_dict['userinfo']['user_name'])
+    response, status_code = authx.auth.set_service_store_secret("opa", key=f"users/{safe_name}", value=json.dumps(user_dict))
+    return response, status_code
+
+
+def get_user(user_name):
+    safe_name = urllib.parse.quote_plus(user_name)
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"users/{safe_name}")
+    # return 404 if the user is not found
+    if status_code == 404:
+        response = {"error": f"User {user_name} is not an authorized CanDIG user"}
+    return response, status_code
+
+
+def get_self(token):
+    user_name = authx.auth.get_user_id(None, token=token)
+    if user_name is None:
+        return {"error": "User token is not valid"}, 404
+    response, status_code = get_user(user_name)
+    return response, status_code
+
+
+def remove_user(user_name):
+    safe_name = urllib.parse.quote_plus(user_name)
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"users/{safe_name}")
+    if status_code == 200:
+        response, status_code = authx.auth.delete_service_store_secret("opa", key=f"users/{safe_name}")
+        # if the user was preapproved, take them out of that list
+        remove_preapproved_user(user_name)
+
+        # remove the user from any site roles:
+        site_roles, status_code = list_role_types()
+        for role_type in site_roles:
+            members, status_code = get_role_type(role_type)
+            if user_name in members:
+                members.remove(user_name)
+                set_role_type(role_type, members)
+
+        # remove the user from any program roles:
+        programs, status_code = list_programs()
+        for program_id in programs:
+            program, status_code = get_program(program_id)
+            if user_name in program["program_curators"]:
+                program["program_curators"].remove(user_name)
+            if user_name in program["team_members"]:
+                program["team_members"].remove(user_name)
+            add_program(program)
+        return {"message": f"User {user_name} was removed"}, 200
+    return {"error": f"User {user_name} could not be removed"}, status_code
+
+
+#####
+# Pending user authorizations
+#####
+
+def add_pending_user(token):
+    # NB: any user that has been authenticated by the IDP should be able to add themselves to the pending user list
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"pending_users")
+    if status_code != 200:
+        return response, status_code
+
+    user_name = authx.auth.get_user_id(None, token=token)
+    if user_name is None:
+        return {"error": "Could not verify jwt or obtain user ID"}, 403
+
+    user_dict, status_code = get_user(user_name)
+    if status_code != 404:
+        if "sample_jwt" not in user_dict["userinfo"]:
+            user_dict["userinfo"]["sample_jwt"] = token
+        else:
+            return {"message": f"User {user_name} is already a CanDIG authorized user"}, 200
+    else:
+        user_dict = {
+            "userinfo": {
+                "user_name": user_name,
+                "sample_jwt": token
+            }
+        }
+    if user_name not in response["pending_users"]:
+        response["pending_users"][user_name] = user_dict
+
+        response, status_code = authx.auth.set_service_store_secret("opa", key=f"pending_users", value=json.dumps(response))
+
+        if status_code == 200:
+            preapproved_users, status_code = list_preapproved_users()
+            if status_code == 200:
+                if user_name in preapproved_users:
+                    return approve_pending_user(user_name)
+            return response, 201 # return 201 to indicate that the user was added to the list
+    else:
+        # return 200 to indicate OK but nothing was added
+        return {"message": f"User {user_name} already pending"}, 200
+    return response, status_code
+
+
+def list_pending_users():
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"pending_users")
+    if status_code == 200:
+        response = list(response["pending_users"].keys())
+    return response, status_code
+
+
+def is_user_pending(token):
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"pending_users")
+    if status_code == 200:
+        user_name = authx.auth.get_user_id(None, token=token)
+        response = user_name in response["pending_users"]
+    else:
+        response = False
+    return response, status_code
+
+
+def approve_pending_user(user_name):
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"pending_users")
+    if status_code != 200:
+        return response, status_code
+    pending_users = response["pending_users"]
+    if user_name in pending_users:
+        user_dict = pending_users[user_name]
+        if "dac_authorizations" not in user_dict:
+            user_dict["dac_authorizations"] = {}
+        response2, status_code = write_user(user_dict)
+        if status_code == 200:
+            pending_users.pop(user_name)
+            response3, status_code = authx.auth.set_service_store_secret("opa", key=f"pending_users", value=json.dumps(response))
+            return {"message": f"User {user_name} has been approved"}, status_code
+        return response2, status_code
+    else:
+        return {"error": f"no pending user with ID {user_name}"}, 404
+
+
+def reject_pending_user(user_name):
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"pending_users")
+    if status_code != 200:
+        return response, status_code
+    pending_users = response["pending_users"]
+
+    if user_name in pending_users:
+        pending_users.pop(user_name)
+        response, status_code = authx.auth.set_service_store_secret("opa", key=f"pending_users", value=json.dumps({"pending_users": pending_users}))
+
+    else:
+        return {"error": f"no pending user with ID {user_name}"}, 404
+    return response, status_code
+
+
+def clear_pending_users():
+    response, status_code = authx.auth.set_service_store_secret("opa", key="pending_users", value=json.dumps({"pending_users": {}}))
+    return response, status_code
+
+
+#####
+# Preapproved user authorizations
+#####
+
+def list_preapproved_users():
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"preapproved_users")
+    if status_code == 200:
+        response = response["preapproved_users"]
+    return response, status_code
+
+
+def clear_preapproved_users():
+    response, status_code = authx.auth.set_service_store_secret("opa", key="preapproved_users", value=json.dumps({"preapproved_users": []}))
+    return response, status_code
+
+
+def get_preapproved_user(user_name):
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"preapproved_users")
+    if status_code == 200:
+        response = user_name in response["preapproved_users"]
+    else:
+        response = False
+    return response, status_code
+
+
+def add_preapproved_user(user_name):
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"preapproved_users")
+
+    if user_name in response["preapproved_users"]:
+        # return 200 to indicate OK but nothing was added
+        return {"message": f"User {user_name} already preapproved"}, 200
+
+    response["preapproved_users"].append(user_name)
+
+    response, status_code = authx.auth.set_service_store_secret("opa", key=f"preapproved_users", value=json.dumps(response))
+    if status_code == 200:
+        return response, 201 # 201 created, to indicate that we added the user
+    return response, status_code
+
+
+def remove_preapproved_user(user_name):
+    response, status_code = authx.auth.get_service_store_secret("opa", key=f"preapproved_users")
+    if status_code != 200:
+        return response, status_code
+    preapproved_users = response["preapproved_users"]
+
+    if user_name in preapproved_users:
+        preapproved_users.remove(user_name)
+        response, status_code = authx.auth.set_service_store_secret("opa", key=f"preapproved_users", value=json.dumps({"preapproved_users": preapproved_users}))
+
+    else:
+        return {"error": f"no preapproved user with ID {user_name}"}, 404
+    return response, status_code

--- a/src/api/authz_operations.py
+++ b/src/api/authz_operations.py
@@ -1,0 +1,579 @@
+import connexion
+import os
+import re
+import urllib.parse
+from datetime import datetime
+import auth
+import authx.auth
+import tempfile
+import json
+from candigv2_logging.logging import CanDIGLogger
+
+
+logger = CanDIGLogger(__file__)
+
+
+app = connexion.AsyncApp(__name__)
+
+
+# API endpoints
+def get_service_info():
+    return {
+        "id": "org.candig.api.authz",
+        "name": "CanDIG Authorization",
+        "description": "Authorization endpoints for CanDIGv3",
+        "organization": {
+            "name": "CanDIG",
+            "url": "https://www.distributedgenomics.ca"
+        }
+    }
+
+
+####
+# S3 credentials
+####
+
+async def add_s3_credential():
+    data = await connexion.request.json()
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/s3-credential", program=None):
+        return {"error": "Not authorized to store aws credentials"}, 403
+
+    # test endpoint before storing:
+    response, status_code = authx.auth.get_s3_url(object_id="None", s3_endpoint=data["endpoint"], bucket=data["bucket"], access_key=data["access_key"], secret_key=data["secret_key"])
+    # we won't actually get an s3 url because we have no object:
+    # we should expect the error to be a KeyError on the object_id of None.
+    if status_code == 500 and "object_name: None" in response["error"]:
+        response, status_code = authx.auth.store_aws_credential(endpoint=data["endpoint"], bucket=data["bucket"], access=data["access_key"], secret=data["secret_key"])
+        return response, status_code
+    return response, 400
+
+
+@app.route('/s3-credential/endpoint/<path:endpoint_id>/bucket/<path:bucket_id>')
+def get_s3_credential(endpoint_id, bucket_id):
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/s3-credential", program=None):
+        return {"error": "Not authorized to view aws credentials"}, 403
+    endpoint_cleaned = re.sub(r"\W", "_", endpoint_id)
+    return authx.auth.get_aws_credential(endpoint=endpoint_cleaned, bucket=bucket_id)
+
+
+@app.route('/s3-credential/endpoint/<path:endpoint_id>/bucket/<path:bucket_id>')
+def delete_s3_credential(endpoint_id, bucket_id):
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+    if not authx.auth.is_action_allowed_for_program(token, method="DELETE", path="/ingest/s3-credential", program=None):
+        return {"error": "Not authorized to remove aws credentials"}, 403
+    endpoint_cleaned = re.sub(r"\W", "_", endpoint_id)
+    return authx.auth.remove_aws_credential(endpoint=endpoint_cleaned, bucket=bucket_id)
+
+
+####
+# Site roles
+####
+
+@app.route('/site-role/<path:role_type>')
+def list_role(role_type):
+    try:
+        token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+        if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/site-role", program=None):
+            return {"error": f"User not authorized to list site roles"}, 403
+
+        result, status_code = auth.get_role_type(role_type)
+        return result, status_code
+    except Exception as e:
+        return {"error": str(e)}, 500
+
+
+@app.route('/site-role/<path:role_type>/user_id/<path:user_id>')
+def is_user_in_role(role_type, user_id):
+    try:
+        token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+
+        if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/site-role", program=None):
+            return {"error": f"User not authorized to list site roles"}, 403
+
+        result, status_code = auth.get_role_type(role_type)
+        if status_code == 200:
+            return (user_id in result[role_type]), 200
+        return result, status_code
+    except Exception as e:
+        return {"error": str(e)}, 500
+
+
+@app.route('/site-role/<path:role_type>/user_id/<path:user_id>')
+def add_user_to_role(role_type, user_id):
+    try:
+        token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+        if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/site-role", program=None):
+            return {"error": f"User not authorized to add to site roles"}, 403
+
+        result, status_code = auth.get_role_type(role_type)
+        if status_code == 200:
+            if user_id not in result[role_type]:
+                result[role_type].append(user_id)
+                result, status_code = auth.set_role_type(role_type, result[role_type])
+        return result, status_code
+    except Exception as e:
+        return {"error": str(e)}, 500
+
+
+@app.route('/site-role/<path:role_type>/user_id/<path:user_id>')
+def remove_user_from_role(role_type, user_id):
+    try:
+        token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+        if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/site-role", program=None):
+            return {"error": f"User not authorized to remove users from site roles"}, 403
+
+        result, status_code = auth.get_role_type(role_type)
+        if status_code == 200:
+            if user_id in result[role_type]:
+                if role_type == "admin" and len(result[role_type]) == 1:
+                    return {"error": "You cannot remove the only site administrator. Add a new site admin before removing this user from the role."}
+                result[role_type].remove(user_id)
+                result, status_code = auth.set_role_type(role_type, result[role_type])
+            else:
+                return {"error": f"User {user_id} not found in role {role_type}"}, 404
+        return result, status_code
+    except Exception as e:
+        return {"error": str(e)}, 500
+
+
+####
+# Program authorizations
+####
+
+def list_programs():
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/program", program=None):
+        return {"error": f"User not authorized to list programs"}, 403
+
+    response, status_code = auth.list_programs()
+    return response, status_code
+
+
+async def add_program():
+    program = await connexion.request.json()
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/v1/authz/program", program=program['program_id']):
+        return {"error": f"User not authorized to add program {program['program_id']}"}, 403
+
+    response, status_code = auth.add_program(program)
+    if status_code == 200:
+        response = response[program["program_id"]]
+    check_default_site_admin(response)
+    return response, status_code
+
+
+@app.route('/program/<path:program_id>')
+def get_program(program_id):
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/program", program=program_id):
+        return {"error": f"User not authorized to get program {program_id}"}, 403
+
+    response, status_code = auth.get_program(program_id)
+    if status_code == 200:
+        if "dac_authorizations" in response:
+            response.pop("dac_authorizations")
+
+    return response, status_code
+
+
+@app.route('/program/<path:program_id>/dac_authorization')
+def get_program_dacs(program_id):
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/program", program=program_id):
+        return {"error": f"User not authorized to get program {program_id}"}, 403
+
+    response, status_code = auth.get_program(program_id)
+    dac_authz = {}
+
+    if status_code == 200:
+        if "dac_authorizations" in response:
+            dac_authz = response.pop("dac_authorizations")
+
+    return dac_authz, status_code
+
+
+@app.route('/program/<path:program_id>')
+def remove_program(program_id):
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+
+    if not authx.auth.is_action_allowed_for_program(token, method="DELETE", path="/ingest/program", program=program_id):
+        return {"error": "User not authorized to remove programs"}, 403
+
+    response = {"errors": {}}
+    check_default_site_admin(response)
+
+    opa_response, opa_status = auth.remove_program(program_id)
+    logger.info(opa_response)
+    if opa_status == 404:
+        # htsget status is not included here because it doesn't have a 404 response
+        return {"message": f"Program {program_id} not found"}, 404
+
+    if opa_status != 200:
+        response["errors"]["opa"] = {"message": opa_response, "status_code": opa_status}
+
+    if len(response["errors"]) == 0:
+        response.pop("errors")
+        response["message"] = f"Program {program_id} successfully deleted"
+        return response, 200
+
+    return response, 500
+
+
+####
+# Pending users: approving a pending user creates a CanDIG-authorized user
+####
+
+def add_pending_user():
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+
+    response, status_code = auth.add_pending_user(token)
+    return response, status_code
+
+
+def list_pending_users():
+    if not authx.auth.is_site_admin(connexion.request):
+        return {"error": f"User not authorized to list pending users"}, 403
+
+    response, status_code = auth.list_pending_users()
+    return {"results": response}, status_code
+
+
+@app.route('/user/pending/<path:user_id>')
+def is_user_pending(user_id):
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path=f"/ingest/user/pending/{user_id}", program=None):
+        return {"error": "User not authorized to list programs for user"}, 403
+
+    if user_id == "me":
+        user_id = authx.auth.get_user_id(connexion.request)
+
+    user_name = urllib.parse.unquote_plus(user_id)
+
+    pending_users, status_code = auth.list_pending_users()
+    if status_code == 200:
+        return user_name in pending_users
+    return False, 404
+
+
+@app.route('/user/pending/<path:user_id>')
+def approve_pending_user(user_id):
+    if not authx.auth.is_site_admin(connexion.request):
+        return {"error": f"User not authorized to approve pending users"}, 403
+
+    user_name = urllib.parse.unquote_plus(user_id)
+
+    response, status_code = auth.approve_pending_user(user_name)
+    return response, status_code
+
+
+@app.route('/user/pending/<path:user_id>')
+def reject_pending_user(user_id):
+    if not authx.auth.is_site_admin(connexion.request):
+        return {"error": f"User not authorized to reject pending users"}, 403
+
+    user_name = urllib.parse.unquote_plus(user_id)
+
+    response, status_code = auth.reject_pending_user(user_name)
+    return response, status_code
+
+
+async def approve_pending_users():
+    users = await connexion.request.json()
+    if not authx.auth.is_site_admin(connexion.request):
+        return {"error": f"User not authorized to approve pending users"}, 403
+
+    rejected = []
+    approved = []
+    for user_id in users:
+        response, status_code = auth.approve_pending_user(user_id)
+        if status_code != 200:
+            rejected.append(user_id)
+        else:
+            approved.append(user_id)
+    response = {}
+    if len(approved) > 0:
+        response["approved"] = approved
+    if len(rejected) > 0:
+        status_code = 401
+        response["rejected"] = rejected
+    return response, status_code
+
+
+def clear_pending_users():
+    if not authx.auth.is_site_admin(connexion.request):
+        return {"error": f"User not authorized to clear pending users"}, 403
+
+    response, status_code = auth.clear_pending_users()
+    return response, status_code
+
+
+####
+# Preapproved users: If a preapproved user requests to be pending, the user will automatically be approved as a CanDIG-authorized user
+####
+
+def list_preapproved_users():
+    if not authx.auth.is_site_admin(connexion.request):
+        return {"error": f"User not authorized to list preapproved users"}, 403
+
+    response, status_code = auth.list_preapproved_users()
+    return {"results": response}, status_code
+
+
+async def add_preapproved_users():
+    users = await connexion.request.json()
+    if not authx.auth.is_site_admin(connexion.request):
+        return {"error": f"User not authorized to add preapproved users"}, 403
+
+    rejected = []
+    for user_id in users:
+        response, status_code = auth.add_preapproved_user(user_id)
+        if status_code not in [200, 201]:
+            rejected.append(user_id)
+    if len(rejected) > 0:
+        status_code = 401
+        response = {"message": f"The following requested user IDs could not be added: {rejected}"}
+    else:
+        response = {"message": "Success"}
+    return response, status_code
+
+
+def clear_preapproved_users():
+    if not authx.auth.is_site_admin(connexion.request):
+        return {"error": f"User not authorized to clear preapproved users"}, 403
+
+    response, status_code = auth.clear_preapproved_users()
+    return response, status_code
+
+
+@app.route('/user/preapproved/<path:user_id>')
+def get_preapproved_user(user_id):
+    if not authx.auth.is_site_admin(connexion.request):
+        return {"error": f"User not authorized to get preapproved users"}, 403
+
+    user_name = urllib.parse.unquote_plus(user_id)
+
+    response, status_code = auth.get_preapproved_user(user_name)
+    return response, status_code
+
+
+@app.route('/user/preapproved/<path:user_id>')
+def add_preapproved_user(user_id):
+    if not authx.auth.is_site_admin(connexion.request):
+        return {"error": f"User not authorized to add preapproved users"}, 403
+
+    user_name = urllib.parse.unquote_plus(user_id)
+
+    response, status_code = auth.add_preapproved_user(user_name)
+    return response, status_code
+
+
+@app.route('/user/preapproved/<path:user_id>')
+def remove_preapproved_user(user_id):
+    if not authx.auth.is_site_admin(connexion.request):
+        return {"error": f"User not authorized to remove preapproved users"}, 403
+
+    user_name = urllib.parse.unquote_plus(user_id)
+
+    response, status_code = auth.remove_preapproved_user(user_name)
+    return response, status_code
+
+
+####
+# DAC authorization for users
+####
+
+@app.route('/user/<path:user_id>')
+def list_authz_for_user(user_id):
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+
+    status_code = 0
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path=f"/ingest/user/{user_id}", program=None):
+        return {"error": "User not authorized to list programs for user"}, 403
+
+    self_checkup = user_id == "me"
+    if user_id == "me":
+        user_id = authx.auth.get_user_id(connexion.request)
+
+    user_result, status_code = auth.get_user(user_id)
+    if status_code != 200:
+        return user_result, status_code
+
+    user_result["site_roles"] = []
+    role_types, status_code = auth.list_role_types()
+    if status_code == 200:
+        for role_type in role_types:
+            users, status_code = auth.get_role_type(role_type)
+            if user_id in users[role_type]:
+                user_result["site_roles"].append(role_type)
+
+    user_result["program_authorizations"] = {}
+
+    user_token = None
+    user_key = None
+    if self_checkup:
+        user_token = token
+    elif "sample_jwt" in user_result["userinfo"]:
+        user_token = user_result["userinfo"].pop("sample_jwt")
+    else:
+        user_key = user_id
+    opa_permissions, opa_status_code = authx.auth.get_opa_permissions(
+        bearer_token=token,
+        user_token=user_token,
+        user_key=user_key
+    )
+    if opa_status_code == 200:
+        user_result["program_authorizations"]["team_member"] = opa_permissions["debug"]["user_key_has_team_member_programs"]
+        user_result["program_authorizations"]["program_curator"] = opa_permissions["debug"]["user_key_has_curator_programs"]
+
+    user_result["program_authorizations"]["dac_authorizations"] = user_result.pop("dac_authorizations")
+    user_result["userinfo"]["is_candig_authorized"] = opa_permissions["user_is_candig_authorized"]
+    return user_result, status_code
+
+
+@app.route('/user/<path:user_id>')
+def revoke_authz_for_user(user_id):
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+
+    if not authx.auth.is_action_allowed_for_program(token, method="DELETE", path=f"/ingest/user/{user_id}", program=None):
+        return {"error": "User not authorized to revoke authorization for users"}, 403
+
+    response, status_code = auth.remove_user(user_id)
+    return response, status_code
+
+
+@app.route('/user/<path:user_id>/dac_authorization')
+async def add_dac_authz_for_user(user_id):
+    program_body = await connexion.request.json()
+
+    if "dict" in str(type(program_body)):
+        # if the body was a dict, make it an array
+        program_body = [program_body]
+
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+    user_dict, status_code = auth.get_user(user_id)
+    if status_code != 200:
+        user_dict = {
+            "userinfo": {
+                "user_name": user_id
+            },
+            "dac_authorizations": {}
+        }
+
+    all_programs, status_code = auth.list_programs()
+    if status_code != 200:
+        return all_programs, status_code
+
+    errors = []
+
+    # check to see if any of the programs are listed more than once
+    programs = list(map(lambda x: x['program_id'], program_body))
+    if len(programs) > len(set((programs))):
+        return {"error": "Duplicate programs in request"}, 400
+
+    for program_dict in program_body:
+        program_id = program_dict["program_id"]
+        if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/user", program=program_id):
+            errors.append({program_id: "User not authorized to authorize programs for user"})
+
+        # we need to check to see if the program even exists in the system
+        if program_id not in all_programs:
+            errors.append({program_id: f"Program {program_id} does not exist in {all_programs}"})
+
+        try:
+            if datetime.fromisoformat(program_dict['end_date']) < datetime.fromisoformat(program_dict['start_date']):
+                errors.append({program_id: f"Start date {program_dict['start_date']} cannot be later than end date {program_dict['end_date']}"})
+            elif datetime.fromisoformat(program_dict['end_date']) == datetime.fromisoformat(program_dict['start_date']):
+                errors.append({program_id: f"Start date {program_dict['start_date']} is the same as end date {program_dict['end_date']}"})
+            elif datetime.fromisoformat(program_dict['end_date']) < datetime.now():
+                errors.append({program_id: f"Start date {program_dict['start_date']} and end date {program_dict['end_date']} are in the past"})
+        except Exception as e:
+            errors.append({program_id: f"Date format error: {type(e)} {str(e)}"})
+        user_dict["dac_authorizations"][program_id] = program_dict
+
+        # add this dac to the program's authz
+        program, status_code = auth.get_program(program_id)
+        if status_code == 200:
+            if "dac_authorizations" not in program:
+                program["dac_authorizations"] = {}
+            program["dac_authorizations"][user_id] = program_dict
+            response, status_code = auth.add_program(program)
+            logger.debug(response, status_code)
+            if status_code != 200:
+                errors.append({program_id: response})
+
+    if len(errors) == 0:
+        user_dict, status_code = auth.write_user(user_dict)
+        if "sample_jwt" in user_dict["userinfo"]:
+            user_dict["userinfo"].pop("sample_jwt")
+        return user_dict, status_code
+    return errors, 400
+
+
+@app.route('/user/<path:user_id>/dac_authorization/<path:program_id>')
+def get_dac_authz_for_user(user_id, program_id):
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/user", program=None):
+        return {"error": "User not authorized to get programs for user"}, 403
+
+    user_dict, status_code = auth.get_user(user_id)
+    if status_code != 200:
+        return user_dict, status_code
+    if "sample_jwt" in user_dict["userinfo"]:
+        user_dict["userinfo"].pop("sample_jwt")
+    for p in user_dict["dac_authorizations"]:
+        if p == program_id:
+            return p, 200
+    return {"error": f"No program {program_id} found for user"}, status_code
+
+
+@app.route('/user/<path:user_id>/authorize/<path:program_id>')
+def remove_dac_authz_for_user(user_id, program_id):
+    token = connexion.request.headers['Authorization'].split("Bearer ")[1]
+
+    if not authx.auth.is_action_allowed_for_program(token, method="DELETE", path="/ingest/user", program=program_id):
+        return {"error": "User not authorized to remove programs for user"}, 403
+
+    user_dict, status_code = auth.get_user(user_id)
+    if status_code != 200:
+        return user_dict, status_code
+    for p in user_dict["dac_authorizations"]:
+        if p == program_id:
+            user_dict["dac_authorizations"].pop(program_id)
+            user_dict, status_code = auth.write_user(user_dict)
+            if "sample_jwt" in user_dict["userinfo"]:
+                user_dict["userinfo"].pop("sample_jwt")
+            return user_dict, status_code
+    return {"error": f"No program {program_id} found for user"}, status_code
+
+
+@app.route('/get-token')
+def get_token():
+    # Attempt to grab the token via session_id
+    if not hasattr(connexion.request, 'cookies'):
+        return {'error': 'Unable to use the get-token endpoint without cookies'}, 200
+    token = connexion.request.cookies['session_id']
+
+    return {"token": token}, 200
+
+    # Uncomment the below to exchange for a new token and return
+    # that, instead
+    # try:
+    #    response = auth.get_refresh_token(token)
+    #    if "error" in response:
+    #        return {"error": response["error"]}, 500
+    #    return {"token": response["refresh_token"]}, 200
+    #except Exception as e:
+    #    return {"error": str(e)}, 500
+
+
+def check_default_site_admin(response):
+    if auth.is_default_site_admin_set():
+        if "warnings" not in response:
+            response["warnings"] = []
+        response["warnings"].append(f"Default site administrator {os.getenv('DEFAULT_SITE_ADMIN_USER')} is still configured. Use the /ingest/site-role/site_admin endpoint to set a different site admin.")

--- a/src/api/authz_operations.py
+++ b/src/api/authz_operations.py
@@ -430,7 +430,7 @@ def list_authz_for_user(user_id):
         user_result["program_authorizations"]["team_member"] = opa_permissions["debug"]["user_key_has_team_member_programs"]
         user_result["program_authorizations"]["program_curator"] = opa_permissions["debug"]["user_key_has_curator_programs"]
 
-    user_result["program_authorizations"]["dac_authorizations"] = user_result.pop("dac_authorizations")
+    user_result["program_authorizations"]["dac_authorizations"] = list(user_result.pop("dac_authorizations").values())
     user_result["userinfo"]["is_candig_authorized"] = opa_permissions["user_is_candig_authorized"]
     return user_result, status_code
 

--- a/src/api/authz_operations.py
+++ b/src/api/authz_operations.py
@@ -36,7 +36,7 @@ def get_service_info():
 async def add_s3_credential():
     data = await connexion.request.json()
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
-    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/s3-credential", program=None):
+    if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/v1/authz/s3-credential", program=None):
         return {"error": "Not authorized to store aws credentials"}, 403
 
     # test endpoint before storing:
@@ -52,7 +52,7 @@ async def add_s3_credential():
 @app.route('/s3-credential/endpoint/<path:endpoint_id>/bucket/<path:bucket_id>')
 def get_s3_credential(endpoint_id, bucket_id):
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
-    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/s3-credential", program=None):
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/v1/authz/s3-credential", program=None):
         return {"error": "Not authorized to view aws credentials"}, 403
     endpoint_cleaned = re.sub(r"\W", "_", endpoint_id)
     return authx.auth.get_aws_credential(endpoint=endpoint_cleaned, bucket=bucket_id)
@@ -61,7 +61,7 @@ def get_s3_credential(endpoint_id, bucket_id):
 @app.route('/s3-credential/endpoint/<path:endpoint_id>/bucket/<path:bucket_id>')
 def delete_s3_credential(endpoint_id, bucket_id):
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
-    if not authx.auth.is_action_allowed_for_program(token, method="DELETE", path="/ingest/s3-credential", program=None):
+    if not authx.auth.is_action_allowed_for_program(token, method="DELETE", path="/v1/authz/s3-credential", program=None):
         return {"error": "Not authorized to remove aws credentials"}, 403
     endpoint_cleaned = re.sub(r"\W", "_", endpoint_id)
     return authx.auth.remove_aws_credential(endpoint=endpoint_cleaned, bucket=bucket_id)
@@ -75,7 +75,7 @@ def delete_s3_credential(endpoint_id, bucket_id):
 def list_role(role_type):
     try:
         token = connexion.request.headers['Authorization'].split("Bearer ")[1]
-        if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/site-role", program=None):
+        if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/v1/authz/site-role", program=None):
             return {"error": f"User not authorized to list site roles"}, 403
 
         result, status_code = auth.get_role_type(role_type)
@@ -89,7 +89,7 @@ def is_user_in_role(role_type, user_id):
     try:
         token = connexion.request.headers['Authorization'].split("Bearer ")[1]
 
-        if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/site-role", program=None):
+        if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/v1/authz/site-role", program=None):
             return {"error": f"User not authorized to list site roles"}, 403
 
         result, status_code = auth.get_role_type(role_type)
@@ -104,7 +104,7 @@ def is_user_in_role(role_type, user_id):
 def add_user_to_role(role_type, user_id):
     try:
         token = connexion.request.headers['Authorization'].split("Bearer ")[1]
-        if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/site-role", program=None):
+        if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/v1/authz/site-role", program=None):
             return {"error": f"User not authorized to add to site roles"}, 403
 
         result, status_code = auth.get_role_type(role_type)
@@ -121,7 +121,7 @@ def add_user_to_role(role_type, user_id):
 def remove_user_from_role(role_type, user_id):
     try:
         token = connexion.request.headers['Authorization'].split("Bearer ")[1]
-        if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/site-role", program=None):
+        if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/v1/authz/site-role", program=None):
             return {"error": f"User not authorized to remove users from site roles"}, 403
 
         result, status_code = auth.get_role_type(role_type)
@@ -145,7 +145,7 @@ def remove_user_from_role(role_type, user_id):
 def list_programs():
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
 
-    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/program", program=None):
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/v1/authz/program", program=None):
         return {"error": f"User not authorized to list programs"}, 403
 
     response, status_code = auth.list_programs()
@@ -169,7 +169,7 @@ async def add_program():
 def get_program(program_id):
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
 
-    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/program", program=program_id):
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/v1/authz/program", program=program_id):
         return {"error": f"User not authorized to get program {program_id}"}, 403
 
     response, status_code = auth.get_program(program_id)
@@ -184,7 +184,7 @@ def get_program(program_id):
 def get_program_dacs(program_id):
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
 
-    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/program", program=program_id):
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/v1/authz/program", program=program_id):
         return {"error": f"User not authorized to get program {program_id}"}, 403
 
     response, status_code = auth.get_program(program_id)
@@ -201,7 +201,7 @@ def get_program_dacs(program_id):
 def remove_program(program_id):
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
 
-    if not authx.auth.is_action_allowed_for_program(token, method="DELETE", path="/ingest/program", program=program_id):
+    if not authx.auth.is_action_allowed_for_program(token, method="DELETE", path="/v1/authz/program", program=program_id):
         return {"error": "User not authorized to remove programs"}, 403
 
     response = {"errors": {}}
@@ -246,7 +246,7 @@ def list_pending_users():
 @app.route('/user/pending/<path:user_id>')
 def is_user_pending(user_id):
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
-    if not authx.auth.is_action_allowed_for_program(token, method="GET", path=f"/ingest/user/pending/{user_id}", program=None):
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path=f"/v1/authz/user/pending/{user_id}", program=None):
         return {"error": "User not authorized to list programs for user"}, 403
 
     if user_id == "me":
@@ -392,7 +392,7 @@ def list_authz_for_user(user_id):
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
 
     status_code = 0
-    if not authx.auth.is_action_allowed_for_program(token, method="GET", path=f"/ingest/user/{user_id}", program=None):
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path=f"/v1/authz/user/{user_id}", program=None):
         return {"error": "User not authorized to list programs for user"}, 403
 
     self_checkup = user_id == "me"
@@ -439,7 +439,7 @@ def list_authz_for_user(user_id):
 def revoke_authz_for_user(user_id):
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
 
-    if not authx.auth.is_action_allowed_for_program(token, method="DELETE", path=f"/ingest/user/{user_id}", program=None):
+    if not authx.auth.is_action_allowed_for_program(token, method="DELETE", path=f"/v1/authz/user/{user_id}", program=None):
         return {"error": "User not authorized to revoke authorization for users"}, 403
 
     response, status_code = auth.remove_user(user_id)
@@ -477,7 +477,7 @@ async def add_dac_authz_for_user(user_id):
 
     for program_dict in program_body:
         program_id = program_dict["program_id"]
-        if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/ingest/user", program=program_id):
+        if not authx.auth.is_action_allowed_for_program(token, method="POST", path="/v1/authz/user", program=program_id):
             errors.append({program_id: "User not authorized to authorize programs for user"})
 
         # we need to check to see if the program even exists in the system
@@ -518,7 +518,7 @@ async def add_dac_authz_for_user(user_id):
 def get_dac_authz_for_user(user_id, program_id):
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
 
-    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/ingest/user", program=None):
+    if not authx.auth.is_action_allowed_for_program(token, method="GET", path="/v1/authz/user", program=None):
         return {"error": "User not authorized to get programs for user"}, 403
 
     user_dict, status_code = auth.get_user(user_id)
@@ -536,7 +536,7 @@ def get_dac_authz_for_user(user_id, program_id):
 def remove_dac_authz_for_user(user_id, program_id):
     token = connexion.request.headers['Authorization'].split("Bearer ")[1]
 
-    if not authx.auth.is_action_allowed_for_program(token, method="DELETE", path="/ingest/user", program=program_id):
+    if not authx.auth.is_action_allowed_for_program(token, method="DELETE", path="/v1/authz/user", program=program_id):
         return {"error": "User not authorized to remove programs for user"}, 403
 
     user_dict, status_code = auth.get_user(user_id)
@@ -576,4 +576,4 @@ def check_default_site_admin(response):
     if auth.is_default_site_admin_set():
         if "warnings" not in response:
             response["warnings"] = []
-        response["warnings"].append(f"Default site administrator {os.getenv('DEFAULT_SITE_ADMIN_USER')} is still configured. Use the /ingest/site-role/site_admin endpoint to set a different site admin.")
+        response["warnings"].append(f"Default site administrator {os.getenv('DEFAULT_SITE_ADMIN_USER')} is still configured. Use the /v1/authz/site-role/site_admin endpoint to set a different site admin.")

--- a/src/app.py
+++ b/src/app.py
@@ -10,11 +10,14 @@ from contextlib import asynccontextmanager
 from candigv2_logging.logging import CanDIGLogger, initialize
 from connexion import AsyncApp
 
-from .api import beacon_operations, dataset_operations, person_operations, query_operations
+from .api import beacon_operations, dataset_operations, person_operations, query_operations, auth
 
 initialize()
 logger = CanDIGLogger(__file__)
 
+sys.modules["auth"] = auth
+from .api import authz_operations
+sys.modules["authz_operations"] = authz_operations
 sys.modules["query_operations"] = query_operations
 sys.modules["dataset_operations"] = dataset_operations
 sys.modules["person_operations"] = person_operations
@@ -40,6 +43,7 @@ app = AsyncApp(__name__, specification_dir="../", lifespan=lifespan)
 
 app.add_api("schema.yml", validate_responses=True)
 app.add_api("beacon-schema.yml", validate_responses=True)
+app.add_api("authz-schema.yml", validate_responses=True, pythonic_params=True, strict_validation=True)
 
 if __name__ == "__main__":
     app.run(port=8080, reload=False)


### PR DESCRIPTION
# Ticket(s)

- [DIG-2143](https://candig.atlassian.net/browse/DIG-2143)

# Description
Moving over authorization admin functionality from old candig-ingest. 


# Related
<!--- List any related PRs or information here if any exist. --->

-

# To test
<!--- Describe what is needed to test the change --->
I re-enabled tests in CanDIGv3's integration tests; they should be tested there: https://github.com/CanDIG/CanDIGv3/pull/18

## Types of Change(s)

- [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

If breaking, Which other services does it affect?

- [ ] authx
- [ ] data-portal
- [ ] ingest
- [ ] clinical ETL
- [ ] federation
- [ ] htsget-app
- [ ] katsu
- [ ] CanDIG OPA
- [ ] Query

<!--- If a breaking change, describe the impact the PR will have on the services selected above --->

## Has it been tested for:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] Prettier linter doesn't return errors
- [ ] Locally tested
  - [ ] using stable release
  - [ ] using develop branches
- [ ] Dev server tested
- [ ] Production tested when merging into stable/production branch


[DIG-2143]: https://candig.atlassian.net/browse/DIG-2143?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ