### PR TITLE
DIG-2173: Beacon response should skip when concept_id == 0

### DIFF
--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -427,7 +427,7 @@ def discovery_query_primary_site(filter):
         FROM omop.condition_occurrence AS co
         LEFT JOIN omop.concept AS c ON c.concept_id = co.condition_concept_id
         LEFT JOIN omop.person AS p ON p.person_id = co.person_id
-        WHERE TRUE
+        WHERE c.concept_id != 0
         {filter['demographic_filters']}
         {filter['condition_filters']}
         {filter['measurement_filters']}
@@ -442,7 +442,7 @@ def discovery_query_treatment_type(filter):
         FROM omop.procedure_occurrence AS d
         LEFT JOIN omop.concept AS c ON c.concept_id = d.procedure_concept_id
         LEFT JOIN omop.person AS p ON p.person_id = d.person_id
-        WHERE TRUE
+        WHERE c.concept_id != 0
         {filter['demographic_filters']}
         {filter['condition_filters']}
         {filter['measurement_filters']}
@@ -457,7 +457,7 @@ def discovery_query_drug_type(filter):
         FROM omop.drug_exposure AS d
         LEFT JOIN omop.concept AS c ON c.concept_id = d.drug_concept_id
         LEFT JOIN omop.person AS p ON p.person_id = d.person_id
-        WHERE TRUE
+        WHERE c.concept_id != 0
         {filter['demographic_filters']}
         {filter['condition_filters']}
         {filter['measurement_filters']}
@@ -506,7 +506,7 @@ def mapBeaconScopeToOMOP(scope):
     scopeMapping = {mappingDict[scope]:'Age'}
     return scopeMapping
 
-async def format_filtered_response(discovery_query):
+async def format_filtered_discovery(discovery_query):
     retval = {}
     discovery_results = (await basic_query(discovery_query)).fetchall()
     for value, count in discovery_results:
@@ -520,10 +520,10 @@ async def get_discovery(base_filter):
     :param dictTableMap: dictionary of filters from create_dynamic_filter() 
     """
     discovery = get_basic_discovery_response()
-    discovery['primary_site_count'] = await format_filtered_response(discovery_query_primary_site(base_filter))
-    discovery['treatment_type_count'] = await format_filtered_response(discovery_query_treatment_type(base_filter))
-    discovery['patients_per_program'] = await format_filtered_response(discovery_query_program(base_filter))
-    discovery['drug_type_count'] = await format_filtered_response(discovery_query_drug_type(base_filter))
+    discovery['primary_site_count'] = await format_filtered_discovery(discovery_query_primary_site(base_filter))
+    discovery['treatment_type_count'] = await format_filtered_discovery(discovery_query_treatment_type(base_filter))
+    discovery['patients_per_program'] = await format_filtered_discovery(discovery_query_program(base_filter))
+    discovery['drug_type_count'] = await format_filtered_discovery(discovery_query_drug_type(base_filter))
     return discovery
 
 async def checkFilters(filtersDict, offset, limit, typeQuery):
@@ -563,7 +563,7 @@ async def checkFilters(filtersDict, offset, limit, typeQuery):
                             try:
                                 scope = filter['scope']
                             except:
-                                logger.info("You need an scope if you are using 'ageOfOnset'") 
+                                logger.info("You need a scope if you are using 'ageOfOnset'")
                             if "disease" in scope:
                                 filterId = 'ageAtDisease'
                             elif "treatments" in scope:

--- a/src/beacon/omop/mappings.py
+++ b/src/beacon/omop/mappings.py
@@ -4,17 +4,23 @@
 ############################### Individual model  ####################################
 
 def diseases_table_map(dictValues):
-    return {
+    retVal = {
             'diseaseCode': dictValues["condition_concept_id"],
             'ageOfOnset': {'iso8601duration': dictValues["condition_ageOfOnset"]},
         }
+    if retVal['diseaseCode'] is None:
+        del retVal['diseaseCode']
+    return retVal
 
 def procedures_table_map(dictValues):
-    return {
+    retVal = {
             'procedureCode': dictValues["procedure_concept_id"],
             'ageAtProcedure': {'iso8601duration': dictValues["procedure_ageOfOnset"]},
             'dateOfProcedure': dictValues["procedure_date"],
         }
+    if retVal['procedureCode'] is None:
+        del retVal['procedureCode']
+    return retVal
 
 def isfloat(num):
     try:

--- a/src/beacon/omop/utils.py
+++ b/src/beacon/omop/utils.py
@@ -45,15 +45,17 @@ async def search_ontologies(dictValues):
                 # If id in variable, extract the label and OntologyId
                 if "concept_id" in variable:
                     if value == 0:
-                        dictVariableValue[variable] = {'id':"None:No matching concept", 'label':"No matching concept"}
+                        dictVariableValue[variable] = None # {'id':"None:No matching concept", 'label':"No matching concept"}
                         continue
                     records = await search_ontology(value)
                     if records:
                         label = records[0]
                         id = records[1]
                     else:
-                        label = "No matching concept"
-                        id = "None:No matching concept"
+                        # label = "No matching concept"
+                        # id = "None:No matching concept"
+                        dictVariableValue[variable] = None
+                        continue
 
                     dictVariableValue[variable] = {'id':id, 'label':label}
     return dictValues


### PR DESCRIPTION
# Ticket(s)

- [DIG-2173](https://candig.atlassian.net/browse/DIG-2173)

# Description
This removes all instances of procedures, diseases, etc that map to `concept_id==0`, which is `No matching concept`. The idea behind this is to hide anything that is ultimately irrelevant to the user, as these are mismapped samples.
This removes these two in two places:
1. Discovery counts no longer return these values (`.info.drug_type_count`, for instance)
2. Any results with e.g. procedures without a matching code will no longer include it.

For example, a response that used to return
```
                     {
                        "procedureCode":{
                           "id":"None:No matching concept",
                           "label":"No matching concept"
                        },
                        "ageAtProcedure":{
                           "iso8601duration":"P52Y"
                        },
                        "dateOfProcedure":"2000-06-10"
                     }
```
will now exclude it from the response
# To test
There's quite a lot in the synthetic data, so you can load it up and see the removal:
```
curl candig.docker.internal:5080/candig-api/v1/beacon/persons -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d '{"meta": {"apiVersion": "v2.0.0"}, "query": {"requestedGranularity": "record", "filters": [{ "id": "SNOMED:33821000087103" }]}}'
```
The response will no longer include anything with:
```
                        "procedureCode":{
                           "id":"None:No matching concept",
                           "label":"No matching concept"
                        }
```


## Types of Change(s)

- [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 💥 Breaking change (fix or feature that would cause existing functionality to change)

If breaking, Which other services does it affect?

- [ ] authx
- [ ] data-portal
- [ ] ingest
- [ ] clinical ETL
- [ ] federation
- [ ] htsget-app
- [ ] katsu
- [ ] CanDIG OPA
- [ ] Query

<!--- If a breaking change, describe the impact the PR will have on the services selected above --->

## Has it been tested for:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] Prettier linter doesn't return errors
- [ ] Locally tested
  - [ ] using stable release
  - [ ] using develop branches
- [ ] Dev server tested
- [ ] Production tested when merging into stable/production branch


[DIG-2173]: https://candig.atlassian.net/browse/DIG-2173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ