### PR TITLE
In instances where the procedure/disease code doesn't map, completely remove it

### DIFF
--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -193,9 +193,12 @@ def format_query(listIds, dictPerson, dictCondition, dictProcedures, dictMeasure
         if any("race_concept_id" in d for d in dictPerson[person_id]):
             dictId["ethnicity"] = dictPerson[person_id][0]["race_concept_id"]
         if any("condition_concept_id" in d for d in dictCondition[person_id]):
-            dictId["diseases"] = list(map(mappings.diseases_table_map, dictCondition[person_id]))
+            diseases = list(map(mappings.diseases_table_map, dictCondition[person_id]))
+            dictId["diseases"] = [disease for disease in diseases if disease['diseaseCode'] is not None]
         if any("procedure_concept_id" in d for d in dictProcedures[person_id]):
-            dictId["interventionsOrProcedures"] = list(map(mappings.procedures_table_map, dictProcedures[person_id]))
+            procedures = list(map(mappings.procedures_table_map, dictProcedures[person_id]))
+            # clean up any concept_id == 0 responses
+            dictId["interventionsOrProcedures"] = [procedure for procedure in procedures if procedure['procedureCode'] is not None]
         if any("measurement_concept_id" in d for d in dictMeasures[person_id]):
             dictId["measures"] = list(map(mappings.measures_table_map, dictMeasures[person_id]))
         if any("observation_concept_id" in d for d in dictExposures[person_id]):

--- a/src/beacon/omop/mappings.py
+++ b/src/beacon/omop/mappings.py
@@ -4,23 +4,17 @@
 ############################### Individual model  ####################################
 
 def diseases_table_map(dictValues):
-    retVal = {
+    return {
             'diseaseCode': dictValues["condition_concept_id"],
             'ageOfOnset': {'iso8601duration': dictValues["condition_ageOfOnset"]},
         }
-    if retVal['diseaseCode'] is None:
-        del retVal['diseaseCode']
-    return retVal
 
 def procedures_table_map(dictValues):
-    retVal = {
+    return {
             'procedureCode': dictValues["procedure_concept_id"],
             'ageAtProcedure': {'iso8601duration': dictValues["procedure_ageOfOnset"]},
             'dateOfProcedure': dictValues["procedure_date"],
         }
-    if retVal['procedureCode'] is None:
-        del retVal['procedureCode']
-    return retVal
 
 def isfloat(num):
     try:


### PR DESCRIPTION
Revision for 
# Ticket(s)

- [DIG-2173](https://candig.atlassian.net/browse/DIG-2173)

# Description
This PR instead completely removes the procedure/disease when the code doesn't map -- unsure if this is the behaviour we were looking for?

# Related
- #23 

## Types of Change(s)

- [x] 🪲 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

If breaking, Which other services does it affect?

- [ ] authx
- [ ] data-portal
- [ ] ingest
- [ ] clinical ETL
- [ ] federation
- [ ] htsget-app
- [ ] katsu
- [ ] CanDIG OPA
- [ ] Query

<!--- If a breaking change, describe the impact the PR will have on the services selected above --->

## Has it been tested for:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] Prettier linter doesn't return errors
- [ ] Locally tested
  - [ ] using stable release
  - [ ] using develop branches
- [ ] Dev server tested
- [ ] Production tested when merging into stable/production branch


[DIG-2173]: https://candig.atlassian.net/browse/DIG-2173?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ