### PR TITLE
Fixup an issue where users with no datasets allowed would error out

### DIFF
--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -79,7 +79,7 @@ def get_datasets_allowed_filter(filters_dict):
     datasets = authx.auth.get_opa_datasets(request)
     # Create a filter on allowed datasets for this user
     if len(datasets) == 0:
-        return "and false" # No allowed datasets
+        return "and false", filters_dict # No allowed datasets
 
     ret_filter = 'and exists (SELECT 1 FROM candig.person_in_dataset d where p.person_id = d.person_id and ('
     first = True


### PR DESCRIPTION
# Description
Quick bugfix where a user with no datasets enabled would cause a 500 instead of properly returning nothing

## Types of Change(s)

- [x] 🪲 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

If breaking, Which other services does it affect?

- [ ] authx
- [ ] data-portal
- [ ] ingest
- [ ] clinical ETL
- [ ] federation
- [ ] htsget-app
- [ ] katsu
- [ ] CanDIG OPA
- [ ] Query

<!--- If a breaking change, describe the impact the PR will have on the services selected above --->

## Has it been tested for:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] Prettier linter doesn't return errors
- [ ] Locally tested
  - [ ] using stable release
  - [ ] using develop branches
- [ ] Dev server tested
- [ ] Production tested when merging into stable/production branch
