### PR TITLE
Bugfix: Count results should only include allowed datasets

### DIFF
--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -489,6 +489,7 @@ def super_query_count(filter):
         {filter['procedures_filters']}
         {filter['exposures_filters']}
         {filter['treatments_filters']}
+        {filter['datasets_filters']}
 
     """
 


### PR DESCRIPTION
# Description
The count in the response currently ignores dataset-allowances, causing weirdness in the data portal where the user can scroll past the edge of allowed results. This change shouldn't affect anything else in the response (e.g. discovery queries should still be ok)

## Types of Change(s)

- [x] 🪲 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

If breaking, Which other services does it affect?

- [ ] authx
- [ ] data-portal
- [ ] ingest
- [ ] clinical ETL
- [ ] federation
- [ ] htsget-app
- [ ] katsu
- [ ] CanDIG OPA
- [ ] Query

<!--- If a breaking change, describe the impact the PR will have on the services selected above --->

## Has it been tested for:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] Prettier linter doesn't return errors
- [ ] Locally tested
  - [ ] using stable release
  - [ ] using develop branches
- [ ] Dev server tested
- [ ] Production tested when merging into stable/production branch
