### PR TITLE
Fixup: Permissions weren't being checked properly for users/curators in counts&returns

### DIFF
--- a/src/api/beacon_operations.py
+++ b/src/api/beacon_operations.py
@@ -91,14 +91,11 @@ async def post(body: dict):
 # /persons/
 async def post_person(body: dict):
     retval = {}
-    request = connexion.request
-    request.method = "POST",
-    request.path = "/v1/beacon/persons"
     # Figure out what kind of search we should be doing (see beacon/request/routes)
     params = RequestParams(**body).from_request(body)
 
     # Pass out the parsed search parameters to SQL (see beacon/omop/)
-    schema, count, records, discovery_data = await individuals.get_individuals(request, None, params)
+    schema, count, records, discovery_data = await individuals.get_individuals(None, params)
 
     # Fill out the return value with all parameters that belong there (see beacon/response/build_response)
     # Start by assuming max granularity, and downgrade as needed

--- a/src/api/beacon_operations.py
+++ b/src/api/beacon_operations.py
@@ -1,3 +1,5 @@
+import connexion
+
 #from ..beacon.request.handlers import filtering_terms_handler
 from ..beacon.omop import datasets, filtering_terms, individuals
 #from ..beacon.omop.schemas import DefaultSchemas
@@ -89,11 +91,14 @@ async def post(body: dict):
 # /persons/
 async def post_person(body: dict):
     retval = {}
+    request = connexion.request
+    request.method = "POST",
+    request.path = "/v1/beacon/persons"
     # Figure out what kind of search we should be doing (see beacon/request/routes)
     params = RequestParams(**body).from_request(body)
 
     # Pass out the parsed search parameters to SQL (see beacon/omop/)
-    schema, count, records, discovery_data = await individuals.get_individuals(None, params)
+    schema, count, records, discovery_data = await individuals.get_individuals(request, None, params)
 
     # Fill out the return value with all parameters that belong there (see beacon/response/build_response)
     # Start by assuming max granularity, and downgrade as needed

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -7,7 +7,7 @@ from ...beacon.request.model import RequestParams
 from ...beacon.omop.schemas import DefaultSchemas
 from connexion import request
 import aiosql
-from sqlalchemy import text
+from sqlalchemy import text, bindparam
 from ..conf import MAX_LIMIT
 
 import authx.auth
@@ -35,13 +35,17 @@ async def get_individual_id(offset=0, limit=10, person_id=None):
             # we swap it back before continuing
             transformed_sql = individual_queries.sql_get_individuals.sql \
                 .replace("%(limit)s", ":limit") \
-                .replace("%(offset)s", ":offset")
-            records = (await conn.execute(text(transformed_sql), {"limit": limit, "offset": offset})).all()
-            listId = [str(record[0]) for record in records if record[1] in datasets]
+                .replace("%(offset)s", ":offset") \
+                .replace("%(dataset_ids)s", ":dataset_ids")
+            transformed_sql_text = text(transformed_sql).bindparams(bindparam('dataset_ids', expanding=True))
+            records = (await conn.execute(transformed_sql_text, {"limit": limit, "offset": offset, "dataset_ids": datasets})).all()
+            listId = [str(record[0]) for record in records]
         else:
-            transformed_sql = individual_queries.sql_get_individual_id.sql.replace("%(person_id)s", ":person_id")
-            records = (await conn.execute(text(transformed_sql), {"person_id": person_id})).fetchone()
-            listId = [str(records[0])] if records[1] in datasets else []
+            transformed_sql = individual_queries.sql_get_individual_id.sql.replace("%(person_id)s", ":person_id") \
+                .replace("%(dataset_ids)s", ":dataset_ids")
+            transformed_sql_text = text(transformed_sql).bindparams(bindparam('dataset_ids', expanding=True))
+            records = (await conn.execute(transformed_sql, {"person_id": person_id, "dataset_ids": datasets})).fetchone()
+            listId = [str(records[0])]
     return listId
 
 async def get_individuals_person(listIds, filters_dict):

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -1,5 +1,6 @@
 import re
 
+from connexion import request
 from typing import Optional
 from ...beacon.omop.utils import  search_ontologies, basic_query, peek
 from ...beacon.omop import engine, mappings
@@ -26,7 +27,7 @@ def get_basic_discovery_response():
         'patients_per_program': {}
     }
 
-async def get_individual_id(request=None, offset=0, limit=10, person_id=None):
+async def get_individual_id(offset=0, limit=10, person_id=None):
     datasets = authx.auth.get_opa_datasets(request)
     if len(datasets) == 0:
         return []
@@ -81,7 +82,7 @@ async def get_individuals_dataset(listIds, filters_dict):
 
     return dict_dataset
 
-def get_datasets_allowed_filter(filters_dict, request):
+def get_datasets_allowed_filter(filters_dict):
     datasets = authx.auth.get_opa_datasets(request)
     # Create a filter on allowed datasets for this user
     if len(datasets) == 0:
@@ -287,7 +288,7 @@ def safe_column_name(name):
     # We can revisit this later if the above is not a valid assumption
     return re.sub(r'[^a-zA-Z0-9_]', '', name)
 
-def create_dynamic_filter(filters, request):
+def create_dynamic_filter(filters):
     base_filter = {
         'demographic_filters': '',
         'condition_filters': '',
@@ -481,7 +482,7 @@ def create_dynamic_filter(filters, request):
     base_filter['procedures_filters'] += query_procedure
     base_filter['exposures_filters'] += query_exposure
     base_filter['treatments_filters'] += query_treatment
-    base_filter['datasets_filters'], filters_dict = get_datasets_allowed_filter(filters_dict, request)
+    base_filter['datasets_filters'], filters_dict = get_datasets_allowed_filter(filters_dict)
 
     return base_filter, filters_dict
 
@@ -604,7 +605,7 @@ async def get_discovery(base_filter, filters_dict):
     discovery['drug_type_count'] = await format_filtered_discovery(discovery_query_drug_type(base_filter), filters_dict)
     return discovery
 
-async def checkFilters(request, filtersDict, offset, limit):
+async def checkFilters(filtersDict, offset, limit):
     listOfList = []
     dictTableMap = []
     typeQuery = request.method
@@ -684,7 +685,7 @@ async def checkFilters(request, filtersDict, offset, limit):
                     listConcept_id = listConcept_id.union(concept_ids)
                 dictTableMap.append([tableMap, listConcept_id, operator, value])
     # logger.info(dictTableMap)
-    base_filter, filters_dict = create_dynamic_filter(dictTableMap, request)
+    base_filter, filters_dict = create_dynamic_filter(dictTableMap)
     query_count = super_query_count(base_filter)
     count_records = (await basic_query(query_count, filters_dict)).fetchone()[0]
 
@@ -699,11 +700,11 @@ async def checkFilters(request, filtersDict, offset, limit):
     return listOfList, count_records, discovery, filters_dict
 
 # /individuals/?filters=SNOMED:0&filters=OMOP:23
-async def filters(request, filtersDict, offset, limit):
+async def filters(filtersDict, offset, limit):
     # There used to be a lot of code here, but now that we pass the connexion request it's all unnecessary
-    return await checkFilters(request, filtersDict, offset, limit)
+    return await checkFilters(filtersDict, offset, limit)
 
-async def get_individuals(request: dict, entry_id: Optional[str]=None, qparams: RequestParams=RequestParams()):
+async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=RequestParams()):
 
     schema = DefaultSchemas.INDIVIDUALS
     count_ids = 0
@@ -712,8 +713,7 @@ async def get_individuals(request: dict, entry_id: Optional[str]=None, qparams: 
         qparams.query.pagination.limit = MAX_LIMIT
     if qparams.query.filters and len(qparams.query.filters) > 0 and len(qparams.query.filters[0]) > 0:
         # NB: qparams.query.filters is a list, whereas we need it to be a dict?
-        listIds, count_ids, discovery_data, filters_dict = await filters(request,
-                                                                        qparams.query.filters[0],
+        listIds, count_ids, discovery_data, filters_dict = await filters(qparams.query.filters[0],
                                                                         offset=qparams.query.pagination.skip,
                                                                         limit=qparams.query.pagination.limit)
         if count_ids == 0:
@@ -724,8 +724,7 @@ async def get_individuals(request: dict, entry_id: Optional[str]=None, qparams: 
             listIds = []
             count_ids = 0
         else:
-            listIds = await get_individual_id(request=request,
-                                                offset=qparams.query.pagination.skip,
+            listIds = await get_individual_id(offset=qparams.query.pagination.skip,
                                                 limit=qparams.query.pagination.limit,
                                                 person_id=entry_id)                 # List with all Ids
             async with engine.connect() as conn:
@@ -735,7 +734,7 @@ async def get_individuals(request: dict, entry_id: Optional[str]=None, qparams: 
                 count_ids = await conn.execute(count_sql_text, {"dataset_ids": datasets})
                 count_ids = count_ids.first()[0]
 
-        base_filter, filters_dict = create_dynamic_filter([], request)
+        base_filter, filters_dict = create_dynamic_filter([])
         discovery_data = await get_discovery(base_filter, filters_dict)
 
     # logger.info(f"Number of ids: ${count_ids}")

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -732,7 +732,7 @@ async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=R
             datasets = authx.auth.get_opa_datasets(request)
             count_sql_text = text(individual_queries.count_individuals.sql \
                 .replace("%(dataset_ids)s", ":dataset_ids"))
-            count_sql_text.bindparams(bindparam("dataset_ids", expanding=True))
+            count_sql_text = count_sql_text.bindparams(bindparam("dataset_ids", expanding=True))
             count_ids = await conn.execute(count_sql_text, {"dataset_ids": datasets})
             count_ids = count_ids.first()[0]
             base_filter, filters_dict = create_dynamic_filter([])

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -729,7 +729,11 @@ async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=R
                                             limit=qparams.query.pagination.limit,
                                             person_id=entry_id)                 # List with all Ids
         async with engine.connect() as conn:
-            count_ids = await conn.execute(text(individual_queries.count_individuals.sql)) # Count individuals
+            datasets = authx.auth.get_opa_datasets(request)
+            count_sql_text = text(individual_queries.count_individuals.sql) \
+                .replace("%(dataset_ids)s", ":dataset_ids")
+            count_sql_text.bindparams(bindparam("dataset_ids", expanding=True))
+            count_ids = await conn.execute(count_sql_text, {"dataset_ids": datasets})
             count_ids = count_ids.first()[0]
             base_filter, filters_dict = create_dynamic_filter([])
             discovery_data = await get_discovery(base_filter, filters_dict)

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -5,7 +5,6 @@ from ...beacon.omop.utils import  search_ontologies, basic_query, peek
 from ...beacon.omop import engine, mappings
 from ...beacon.request.model import RequestParams
 from ...beacon.omop.schemas import DefaultSchemas
-from connexion import request
 import aiosql
 from sqlalchemy import text, bindparam
 from ..conf import MAX_LIMIT
@@ -27,7 +26,7 @@ def get_basic_discovery_response():
         'patients_per_program': {}
     }
 
-async def get_individual_id(offset=0, limit=10, person_id=None):
+async def get_individual_id(request=None, offset=0, limit=10, person_id=None):
     datasets = authx.auth.get_opa_datasets(request)
     if len(datasets) == 0:
         return []
@@ -82,7 +81,7 @@ async def get_individuals_dataset(listIds, filters_dict):
 
     return dict_dataset
 
-def get_datasets_allowed_filter(filters_dict):
+def get_datasets_allowed_filter(filters_dict, request):
     datasets = authx.auth.get_opa_datasets(request)
     # Create a filter on allowed datasets for this user
     if len(datasets) == 0:
@@ -288,7 +287,7 @@ def safe_column_name(name):
     # We can revisit this later if the above is not a valid assumption
     return re.sub(r'[^a-zA-Z0-9_]', '', name)
 
-def create_dynamic_filter(filters):
+def create_dynamic_filter(filters, request):
     base_filter = {
         'demographic_filters': '',
         'condition_filters': '',
@@ -482,7 +481,7 @@ def create_dynamic_filter(filters):
     base_filter['procedures_filters'] += query_procedure
     base_filter['exposures_filters'] += query_exposure
     base_filter['treatments_filters'] += query_treatment
-    base_filter['datasets_filters'], filters_dict = get_datasets_allowed_filter(filters_dict)
+    base_filter['datasets_filters'], filters_dict = get_datasets_allowed_filter(filters_dict, request)
 
     return base_filter, filters_dict
 
@@ -605,9 +604,10 @@ async def get_discovery(base_filter, filters_dict):
     discovery['drug_type_count'] = await format_filtered_discovery(discovery_query_drug_type(base_filter), filters_dict)
     return discovery
 
-async def checkFilters(filtersDict, offset, limit, typeQuery):
+async def checkFilters(request, filtersDict, offset, limit):
     listOfList = []
     dictTableMap = []
+    typeQuery = request.method
     async with engine.connect() as conn:
         for filter in filtersDict:
             listConcept_id = set()
@@ -684,7 +684,7 @@ async def checkFilters(filtersDict, offset, limit, typeQuery):
                     listConcept_id = listConcept_id.union(concept_ids)
                 dictTableMap.append([tableMap, listConcept_id, operator, value])
     # logger.info(dictTableMap)
-    base_filter, filters_dict = create_dynamic_filter(dictTableMap)
+    base_filter, filters_dict = create_dynamic_filter(dictTableMap, request)
     query_count = super_query_count(base_filter)
     count_records = (await basic_query(query_count, filters_dict)).fetchone()[0]
 
@@ -699,18 +699,11 @@ async def checkFilters(filtersDict, offset, limit, typeQuery):
     return listOfList, count_records, discovery, filters_dict
 
 # /individuals/?filters=SNOMED:0&filters=OMOP:23
-async def filters(filtersDict, offset, limit):
-    # logger.info(filtersDict)
-    if type(filtersDict[0]) is dict:         # If filter is from Post
-        # logger.info("post")
-        listFilters, count, discovery, filters_dict = await checkFilters(filtersDict, offset, limit, 'POST')
-    else:
-        # logger.info("get")
-        listFilters, count, discovery, filters_dict = await checkFilters(filtersDict, offset, limit, 'GET')
+async def filters(request, filtersDict, offset, limit):
+    # There used to be a lot of code here, but now that we pass the connexion request it's all unnecessary
+    return await checkFilters(request, filtersDict, offset, limit)
 
-    return listFilters, count, discovery, filters_dict
-
-async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=RequestParams()):
+async def get_individuals(request: dict, entry_id: Optional[str]=None, qparams: RequestParams=RequestParams()):
 
     schema = DefaultSchemas.INDIVIDUALS
     count_ids = 0
@@ -719,9 +712,10 @@ async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=R
         qparams.query.pagination.limit = MAX_LIMIT
     if qparams.query.filters and len(qparams.query.filters) > 0 and len(qparams.query.filters[0]) > 0:
         # NB: qparams.query.filters is a list, whereas we need it to be a dict?
-        listIds, count_ids, discovery_data, filters_dict = await filters(qparams.query.filters[0],
-                        offset=qparams.query.pagination.skip,
-                        limit=qparams.query.pagination.limit)
+        listIds, count_ids, discovery_data, filters_dict = await filters(request,
+                                                                        qparams.query.filters[0],
+                                                                        offset=qparams.query.pagination.skip,
+                                                                        limit=qparams.query.pagination.limit)
         if count_ids == 0:
             return schema, count_ids, [], {}
     else:
@@ -730,7 +724,8 @@ async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=R
             listIds = []
             count_ids = 0
         else:
-            listIds = await get_individual_id(offset=qparams.query.pagination.skip,
+            listIds = await get_individual_id(request=request,
+                                                offset=qparams.query.pagination.skip,
                                                 limit=qparams.query.pagination.limit,
                                                 person_id=entry_id)                 # List with all Ids
             async with engine.connect() as conn:
@@ -740,7 +735,7 @@ async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=R
                 count_ids = await conn.execute(count_sql_text, {"dataset_ids": datasets})
                 count_ids = count_ids.first()[0]
 
-        base_filter, filters_dict = create_dynamic_filter([])
+        base_filter, filters_dict = create_dynamic_filter([], request)
         discovery_data = await get_discovery(base_filter, filters_dict)
 
     # logger.info(f"Number of ids: ${count_ids}")

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -725,18 +725,23 @@ async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=R
         if count_ids == 0:
             return schema, count_ids, [], {}
     else:
-        listIds = await get_individual_id(offset=qparams.query.pagination.skip,
-                                            limit=qparams.query.pagination.limit,
-                                            person_id=entry_id)                 # List with all Ids
-        async with engine.connect() as conn:
-            datasets = authx.auth.get_opa_datasets(request)
-            count_sql_text = text(individual_queries.count_individuals.sql \
-                .replace("%(dataset_ids)s", ":dataset_ids"))
-            count_sql_text = count_sql_text.bindparams(bindparam("dataset_ids", expanding=True))
-            count_ids = await conn.execute(count_sql_text, {"dataset_ids": datasets})
-            count_ids = count_ids.first()[0]
-            base_filter, filters_dict = create_dynamic_filter([])
-            discovery_data = await get_discovery(base_filter, filters_dict)
+        datasets = authx.auth.get_opa_datasets(request)
+        if len(datasets) == 0:
+            listIds = []
+            count_ids = 0
+        else:
+            listIds = await get_individual_id(offset=qparams.query.pagination.skip,
+                                                limit=qparams.query.pagination.limit,
+                                                person_id=entry_id)                 # List with all Ids
+            async with engine.connect() as conn:
+                count_sql_text = text(individual_queries.count_individuals.sql \
+                    .replace("%(dataset_ids)s", ":dataset_ids"))
+                count_sql_text = count_sql_text.bindparams(bindparam("dataset_ids", expanding=True))
+                count_ids = await conn.execute(count_sql_text, {"dataset_ids": datasets})
+                count_ids = count_ids.first()[0]
+
+        base_filter, filters_dict = create_dynamic_filter([])
+        discovery_data = await get_discovery(base_filter, filters_dict)
 
     # logger.info(f"Number of ids: ${count_ids}")
 

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -29,6 +29,9 @@ def get_basic_discovery_response():
 
 async def get_individual_id(offset=0, limit=10, person_id=None):
     datasets = authx.auth.get_opa_datasets(request)
+    if len(datasets) == 0:
+        return []
+
     async with engine.connect() as conn:
         if person_id == None:
             # aiosql likes to swap params like :limit and :offset to %(limit)s and %(offset)s, which is unsafe

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -730,8 +730,8 @@ async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=R
                                             person_id=entry_id)                 # List with all Ids
         async with engine.connect() as conn:
             datasets = authx.auth.get_opa_datasets(request)
-            count_sql_text = text(individual_queries.count_individuals.sql) \
-                .replace("%(dataset_ids)s", ":dataset_ids")
+            count_sql_text = text(individual_queries.count_individuals.sql \
+                .replace("%(dataset_ids)s", ":dataset_ids"))
             count_sql_text.bindparams(bindparam("dataset_ids", expanding=True))
             count_ids = await conn.execute(count_sql_text, {"dataset_ids": datasets})
             count_ids = count_ids.first()[0]

--- a/src/beacon/omop/sql/individuals.sql
+++ b/src/beacon/omop/sql/individuals.sql
@@ -3,6 +3,7 @@
 -- Get individuals
 SELECT person_id, dataset_id
 FROM candig.person_in_dataset
+WHERE dataset_id IN :dataset_ids
 LIMIT :limit
 OFFSET :offset
 
@@ -36,6 +37,7 @@ JOIN omop.person AS p ON p.person_id=c.person_id
 SELECT DISTINCT person_id, dataset_id
 FROM candig.person_in_dataset
 WHERE person_id = :person_id
+AND dataset_id IN :dataset_ids
 
 -- name: sql_get_person
 -- Get gender and race by id

--- a/src/beacon/omop/sql/individuals.sql
+++ b/src/beacon/omop/sql/individuals.sql
@@ -24,7 +24,8 @@ where cohort_definition_id = :cohort_id
 -- name: count_individuals$
 -- Get individuals count
 SELECT count(*)
-FROM omop.person
+FROM candig.person_in_dataset
+WHERE dataset_id IN :dataset_ids
 
 -- name: count_primary_sites$
 -- Get individuals count


### PR DESCRIPTION
# Description
Two major bugfixes:
1. The counts were occasionally off in the return value
2. Logged-in non-admins weren't being given access to data they should have been

# To test
Follow instructions here: https://github.com/CanDIG/CanDIGv3/pull/30

## Types of Change(s)

- [x] 🪲 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

If breaking, Which other services does it affect?

- [ ] authx
- [ ] data-portal
- [ ] ingest
- [ ] clinical ETL
- [ ] federation
- [ ] htsget-app
- [ ] katsu
- [ ] CanDIG OPA
- [ ] Query

<!--- If a breaking change, describe the impact the PR will have on the services selected above --->

## Has it been tested for:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] Prettier linter doesn't return errors
- [ ] Locally tested
  - [ ] using stable release
  - [ ] using develop branches
- [ ] Dev server tested
- [ ] Production tested when merging into stable/production branch
