### PR TITLE
fix response type on preapproved endpoint

### DIFF
--- a/authz-schema.yml
+++ b/authz-schema.yml
@@ -294,9 +294,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: "#/components/schemas/UserInfo"
+                type: object
     post:
       summary: Add preapproved users
       description: Add bulk preapproved users for CanDIG access


### PR DESCRIPTION
response was array but actually returns a dict