### PR TITLE
Fixup: Use AND between categories, and OR within categories of filtering

### DIFF
--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -360,9 +360,10 @@ def create_dynamic_filter(filters):
                     list_concept_id.append(f'{safe_var_name} = :value{i}')
                 i += 1
             query_person_id =  ' or '.join(list_concept_id)
-            # This can be a function to no repeat always the same -> filter[0]
+            # For the final bit of the query, we use AND between categories and OR within a category
+            query_condition += "and" if query_condition == "" else "or"
             query_condition += f"""
-                and exists (
+                exists (
                     select 1
                     from omop.condition_occurrence co
                     where p.person_id = co.person_id
@@ -393,8 +394,10 @@ def create_dynamic_filter(filters):
                     list_concept_id.append(f'{safe_var_name} = :concept{i}')
                 i += 1
             query_person_id =  ' or '.join(list_concept_id)
+            # For the final bit of the query, we use AND between categories and OR within a category
+            query_measurement += "and" if query_measurement == "" else "or"
             query_measurement += f"""
-                and exists (
+                exists (
                     select 1
                     from omop.measurement co
                     where p.person_id = co.person_id
@@ -420,8 +423,10 @@ def create_dynamic_filter(filters):
                     list_concept_id.append(f'{safe_var_name} = :value{i}')
                 i += 1
             query_person_id =  ' or '.join(list_concept_id)
+            # For the final bit of the query, we use AND between categories and OR within a category
+            query_procedure += "and" if query_procedure == "" else "or"
             query_procedure += f"""
-                and exists (
+                exists (
                     select 1
                     from omop.procedure_occurrence co
                     where p.person_id = co.person_id
@@ -447,8 +452,10 @@ def create_dynamic_filter(filters):
                     list_concept_id.append(f'{safe_var_name} = :value{i}')
                 i += 1
             query_person_id =  ' or '.join(list_concept_id)
+            # For the final bit of the query, we use AND between categories and OR within a category
+            query_exposure += "and" if query_exposure == "" else "or"
             query_exposure += f"""
-                and exists (
+                exists (
                     select 1
                     from omop.observation co
                     where p.person_id = co.person_id
@@ -474,8 +481,10 @@ def create_dynamic_filter(filters):
                     list_concept_id.append(f'{safe_var_name} = :value{i}')
                 i += 1
             query_person_id =  ' or '.join(list_concept_id)
+            # For the final bit of the query, we use AND between categories and OR within a category
+            query_treatment += "and" if query_exposure == "" else "or"
             query_treatment += f"""
-                and exists (
+                exists (
                     select 1
                     from omop.drug_exposure co
                     where p.person_id = co.person_id
@@ -498,7 +507,7 @@ def create_dynamic_filter(filters):
     query_treatment += ')'* n_open_treatment
 
     if list_person:
-        base_filter['demographic_filters'] += ' and ( ' + " and ".join(list_person) + ' ) '
+        base_filter['demographic_filters'] += ' and ( ' + " or ".join(list_person) + ' ) '
 
     base_filter['condition_filters'] += query_condition
     base_filter['measurement_filters'] += query_measurement

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -482,7 +482,7 @@ def create_dynamic_filter(filters):
                 i += 1
             query_person_id =  ' or '.join(list_concept_id)
             # For the final bit of the query, we use AND between categories and OR within a category
-            query_treatment += "and" if query_exposure == "" else "or"
+            query_treatment += "and" if query_treatment == "" else "or"
             query_treatment += f"""
                 exists (
                     select 1


### PR DESCRIPTION
# Description
The current filtering uses an AND between all terms of its query. While we might want to allow more complex querying in the future, this PR temporarily restores the old style of filtering where filters in the same category (e.g. two drug types) are OR'd together, while two filters in different categories (e.g. a drug type and a disease type)  are ANDed together.

# To test
Apply two filters in the frontend, and observe the behaviour.

## Types of Change(s)

- [x] 🪲 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

If breaking, Which other services does it affect?

- [ ] authx
- [ ] data-portal
- [ ] ingest
- [ ] clinical ETL
- [ ] federation
- [ ] htsget-app
- [ ] katsu
- [ ] CanDIG OPA
- [ ] Query

<!--- If a breaking change, describe the impact the PR will have on the services selected above --->

## Has it been tested for:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] Prettier linter doesn't return errors
- [ ] Locally tested
  - [ ] using stable release
  - [ ] using develop branches
- [ ] Dev server tested
- [ ] Production tested when merging into stable/production branch
