### PR TITLE
DIG-2216: Fix hardcoded response type

### DIFF
--- a/src/api/beacon_operations.py
+++ b/src/api/beacon_operations.py
@@ -80,7 +80,7 @@ async def post(body: dict):
 
     # Format proper response
     if (granularity == Granularity.RECORD):
-        retval = build_beacon_resultset_response(records, count, params, lambda x, y: x, schema)
+        retval = build_beacon_resultset_response(records, count, params, lambda x, y: x, schema, {}, 'datasets')
     elif granularity == Granularity.COUNT:
         retval = build_beacon_count_response(records, count, params, lambda x, y: x, schema)
     else:
@@ -107,7 +107,7 @@ async def post_person(body: dict):
 
     # Format proper response
     if (granularity == Granularity.RECORD):
-        retval = build_beacon_resultset_response(records, count, params, lambda x, y: x, schema, discovery_data)
+        retval = build_beacon_resultset_response(records, count, params, lambda x, y: x, schema, discovery_data, 'individuals')
     elif granularity == Granularity.COUNT:
         retval = build_beacon_count_response(records, count, params, lambda x, y: x, schema, discovery_data)
     else:

--- a/src/beacon/response/build_response.py
+++ b/src/beacon/response/build_response.py
@@ -1,4 +1,5 @@
-from typing import Optional
+from typing import Optional, AnyStr
+import uuid
 
 from ...beacon import conf
 from ...beacon.omop.schemas import DefaultSchemas
@@ -34,12 +35,12 @@ def build_response_summary(exists, num_total_results):
         }
 
 
-def build_response(data, num_total_results, qparams, func):
+def build_response(data, num_total_results, qparams, func, setType):
     """"Fills the `response` part with the correct format in `results`"""
 
     response = {
-        'id': 'cdm', # TODO: Set the name of the dataset/cohort
-        'setType': 'dataset', # TODO: Set the type of collection
+        'id': uuid.uuid4(),
+        'setType': setType,
         'exists': num_total_results > 0,
         'resultsCount': num_total_results,
         'results': data,
@@ -59,7 +60,8 @@ def build_beacon_resultset_response(data,
                                     qparams: RequestParams,
                                     func_response_type,
                                     entity_schema: DefaultSchemas,
-                                    discovery_data: dict):
+                                    discovery_data: dict,
+                                    dataset_type: AnyStr):
     """"
     Transform data into the Beacon response format.
     """
@@ -69,7 +71,7 @@ def build_beacon_resultset_response(data,
         'responseSummary': build_response_summary(num_total_results > 0, num_total_results),
         # TODO: 'extendedInfo': build_extended_info(),
         'response': {
-            'resultSets': [build_response(data, num_total_results, qparams, func_response_type)]
+            'resultSets': [build_response(data, num_total_results, qparams, func_response_type, dataset_type)]
         },
         'info': discovery_data,
         'beaconHandovers': conf.beacon_handovers,


### PR DESCRIPTION
# Ticket(s)

- [DIG-2216](https://candig.atlassian.net/browse/DIG-2216)

# Description
This fixes two of the hardcoded parts of the response: the resultSet ID and the resultSet type. resultSet type is now set by the endpoint (either `individuals` or `datasets`) and the ID is a uuidv4 that is otherwise not saved.

# To test
Nothing should have broken as part of this

## Types of Change(s)

- [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

If breaking, Which other services does it affect?

- [ ] authx
- [ ] data-portal
- [ ] ingest
- [ ] clinical ETL
- [ ] federation
- [ ] htsget-app
- [ ] katsu
- [ ] CanDIG OPA
- [ ] Query

<!--- If a breaking change, describe the impact the PR will have on the services selected above --->

## Has it been tested for:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] Prettier linter doesn't return errors
- [ ] Locally tested
  - [ ] using stable release
  - [ ] using develop branches
- [ ] Dev server tested
- [ ] Production tested when merging into stable/production branch


[DIG-2216]: https://candig.atlassian.net/browse/DIG-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ