### PR TITLE
DIG-2224: Allow beacon to query over both clinical and genomic data (pt1)

### DIFF
--- a/src/api/beacon_operations.py
+++ b/src/api/beacon_operations.py
@@ -94,6 +94,9 @@ async def post_person(body: dict):
     # Figure out what kind of search we should be doing (see beacon/request/routes)
     params = RequestParams(**body).from_request(body)
 
+    # Before we continue, we should check to make sure that if a genomic search is attempted, it has all required fields
+    # or wait... is that handled by connexion?
+
     # Pass out the parsed search parameters to SQL (see beacon/omop/)
     schema, count, records, discovery_data = await individuals.get_individuals(None, params)
 

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -661,7 +661,7 @@ async def get_discovery(base_filter, filters_dict):
     discovery['drug_type_count'] = await format_filtered_discovery(discovery_query_drug_type(base_filter), filters_dict)
     return discovery
 
-async def checkFilters(filtersDict, offset, limit, extra_filters):
+async def checkFilters(filtersDict, offset, limit, extra_filters, extra_filters_dict):
     listOfList = []
     dictTableMap = []
     typeQuery = request.method
@@ -744,8 +744,8 @@ async def checkFilters(filtersDict, offset, limit, extra_filters):
                 dictTableMap.append([tableMap, listConcept_id, operator, value, includeDescendantTerms])
     # logger.info(dictTableMap)
     base_filter, filters_dict = create_dynamic_filter(dictTableMap)
-    for filter in extra_filters:
-        base_filter.update(filter)
+    base_filter.update(extra_filters)
+    filters_dict.update(extra_filters_dict)
     query_count = super_query_count(base_filter)
     count_records = (await basic_query(query_count, filters_dict)).fetchone()[0]
 
@@ -760,9 +760,9 @@ async def checkFilters(filtersDict, offset, limit, extra_filters):
     return listOfList, count_records, discovery, filters_dict
 
 # /individuals/?filters=SNOMED:0&filters=OMOP:23
-async def filters(filtersDict, offset, limit, extra_filters):
+async def filters(filtersDict, offset, limit, extra_filters, extra_filters_dict):
     # There used to be a lot of code here, but now that we pass the connexion request it's all unnecessary
-    return await checkFilters(filtersDict, offset, limit, extra_filters)
+    return await checkFilters(filtersDict, offset, limit, extra_filters, extra_filters_dict)
 
 
 def search_genomic_variants(qparams: RequestParams=RequestParams()):
@@ -780,6 +780,7 @@ def search_genomic_variants(qparams: RequestParams=RequestParams()):
             'apiVersion': 'v2'
         }
     }
+
     response = requests.post(url=f"{HTSGET_URL}/beacon/v2/g_variants", headers=headers, json=payload)
     found_samples = []
     if response.ok:
@@ -797,7 +798,7 @@ def search_genomic_variants(qparams: RequestParams=RequestParams()):
 
 
 def create_samples_filter(samples: List, filters_dict: dict):
-    ret_filter = 'and exists (SELECT 1 FROM candig.samples d where p.person_id = d.person_id and ('
+    ret_filter = 'and exists (SELECT 1 FROM candig.sample d where p.person_id = d.person_id and ('
     first = True
     for i, sample_id in enumerate(samples):
         # Expecting sample_id to be of the form: dataset_id~specimen_id e.g. SITE_PM2C~SAMPLE_0001
@@ -820,7 +821,8 @@ async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=R
     discovery_data = {}
     
     # First, we determine if we need to join on any genomics results
-    genomics_filters = {}
+    extra_filters = {}
+    extra_filters_dict = {}
     if "g_variant" in qparams.query.request_parameters:
         found_samples = search_genomic_variants(qparams)
 
@@ -829,16 +831,23 @@ async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=R
             return schema, 0, [], {}
 
         # Otherwise, insert this as a single filter with a bunch of entries
-        genomics_filters = {'genomics_filters': create_samples_filter(found_samples)}
+        genomics_filters, genomic_filters_dict = create_samples_filter(found_samples, {})
+        extra_filters['genomics_filters'] = genomics_filters
+        extra_filters_dict.update(genomic_filters_dict)
 
     if qparams.query.pagination.limit == 0:
         qparams.query.pagination.limit = MAX_LIMIT
+    
+    filter_params = []
     if qparams.query.filters and len(qparams.query.filters) > 0 and len(qparams.query.filters[0]) > 0:
+        filter_params = qparams.query.filters[0]
+    if len(filter_params) > 0 or len(extra_filters) > 0:
         # NB: qparams.query.filters is a list, whereas we need it to be a dict?
-        listIds, count_ids, discovery_data, filters_dict = await filters(qparams.query.filters[0],
+        listIds, count_ids, discovery_data, filters_dict = await filters(filter_params,
                                                                         offset=qparams.query.pagination.skip,
                                                                         limit=qparams.query.pagination.limit,
-                                                                        extra_filters=genomics_filters)
+                                                                        extra_filters=extra_filters,
+                                                                        extra_filters_dict=extra_filters_dict)
         if count_ids == 0:
             return schema, count_ids, [], discovery_data
     else:

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -1,7 +1,9 @@
+import os
 import re
+import requests
 
 from connexion import request
-from typing import Optional
+from typing import Optional, List
 from ...beacon.omop.utils import  search_ontologies, basic_query, peek
 from ...beacon.omop import engine, mappings
 from ...beacon.request.model import RequestParams
@@ -18,6 +20,9 @@ logger = CanDIGLogger(__file__)
 
 queries_file = Path(__file__).parent / "sql" / "individuals.sql"
 individual_queries = aiosql.from_path(queries_file, "psycopg2", mandatory_parameters=False)
+
+CANDIG_URL = os.getenv("CANDIG_URL", "")
+HTSGET_URL = os.getenv("HTSGET_URL", f"{CANDIG_URL}/genomics")
 
 def get_basic_discovery_response():
     return {
@@ -298,6 +303,7 @@ def create_dynamic_filter(filters):
         'procedures_filters': '',
         'exposures_filters': '',
         'treatments_filters': '',
+        'genomics_filters': ''  # Not filled out here
     }
     filters_dict = {}
     request_datasets = []
@@ -537,6 +543,7 @@ def super_query_count(filter):
         {filter['exposures_filters']}
         {filter['treatments_filters']}
         {filter['datasets_filters']}
+        {filter['genomics_filters']}
 
     """
 
@@ -649,7 +656,7 @@ async def get_discovery(base_filter, filters_dict):
     discovery['drug_type_count'] = await format_filtered_discovery(discovery_query_drug_type(base_filter), filters_dict)
     return discovery
 
-async def checkFilters(filtersDict, offset, limit):
+async def checkFilters(filtersDict, offset, limit, extra_filters):
     listOfList = []
     dictTableMap = []
     typeQuery = request.method
@@ -732,6 +739,8 @@ async def checkFilters(filtersDict, offset, limit):
                 dictTableMap.append([tableMap, listConcept_id, operator, value, includeDescendantTerms])
     # logger.info(dictTableMap)
     base_filter, filters_dict = create_dynamic_filter(dictTableMap)
+    for filter in extra_filters:
+        base_filter.update(filter)
     query_count = super_query_count(base_filter)
     count_records = (await basic_query(query_count, filters_dict)).fetchone()[0]
 
@@ -739,29 +748,89 @@ async def checkFilters(filtersDict, offset, limit):
     discovery = await get_discovery(base_filter, filters_dict)
 
     query_get = super_query_get(base_filter, offset, limit)
-    # logger.info(query_get)
+    logger.info(query_get)
     records_get = await basic_query(query_get, filters_dict)
     listOfList = [str(record[0]) for record in records_get]
 
     return listOfList, count_records, discovery, filters_dict
 
 # /individuals/?filters=SNOMED:0&filters=OMOP:23
-async def filters(filtersDict, offset, limit):
+async def filters(filtersDict, offset, limit, extra_filters):
     # There used to be a lot of code here, but now that we pass the connexion request it's all unnecessary
-    return await checkFilters(filtersDict, offset, limit)
+    return await checkFilters(filtersDict, offset, limit, extra_filters)
+
+
+def search_genomic_variants(qparams: RequestParams=RequestParams()):
+    # We basically need to form a request to HTSGet and pass all of our qparams.requestParameters.g_variant to them
+    headers = {
+        "X-Service-Token": authx.auth.create_service_token()
+    }
+    logger.info(qparams.query.request_parameters)
+    payload = {
+        'query': {
+            'requestParameters': qparams.query.request_parameters["g_variant"]
+        },
+        'meta': {
+            'apiVersion': 'v2'
+        }
+    }
+    response = requests.post(url=f"{HTSGET_URL}/beacon/v2/g_variants", headers=headers, json=payload)
+    found_samples = []
+    if response.ok:
+        htsget = response.json()
+        for program, results in htsget.get('estimatedResults', {}).items():
+            if not isinstance(results, list):
+                continue
+            for item in results:
+                found_samples.append(item["submitter_sample_id"])
+                # How do we search on this in a performant manner...
+                # Scratch that, we only have a few days left to implement this
+    else:
+        logger.error(f"Received error {response.status_code} while searching HTSGet: {response.reason}")
+    return found_samples
+
+
+def create_samples_filter(samples: List, filters_dict: dict):
+    ret_filter = 'and exists (SELECT 1 FROM candig.samples d where p.person_id = d.person_id and ('
+    first = True
+    for i, sample_id in enumerate(samples):
+        # Expecting sample_id to be of the form: dataset_id~specimen_id e.g. SITE_PM2C~SAMPLE_0001
+        if not first:
+            ret_filter += ' or '
+        first = False
+        ret_filter += f' CONCAT(dataset_id, ''~'', specimen_id) = :samples{i}'
+        filters_dict[f'samples{i}'] = sample_id
+    # Close both the exists clause and also the chain of dataset_id conditionals
+    ret_filter += '))'
+    return ret_filter, filters_dict
+
 
 async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=RequestParams()):
 
     schema = DefaultSchemas.INDIVIDUALS
     count_ids = 0
     discovery_data = {}
+    
+    # First, we determine if we need to join on any genomics results
+    genomics_filters = {}
+    if "g_variant" in qparams.query.request_parameters:
+        found_samples = search_genomic_variants(qparams)
+
+        # If a genomic variant was requested but none was found, exit early
+        if len(found_samples) == 0:
+            return schema, 0, [], {}
+
+        # Otherwise, insert this as a single filter with a bunch of entries
+        genomics_filters = {'genomics_filters': create_samples_filter(found_samples)}
+
     if qparams.query.pagination.limit == 0:
         qparams.query.pagination.limit = MAX_LIMIT
     if qparams.query.filters and len(qparams.query.filters) > 0 and len(qparams.query.filters[0]) > 0:
         # NB: qparams.query.filters is a list, whereas we need it to be a dict?
         listIds, count_ids, discovery_data, filters_dict = await filters(qparams.query.filters[0],
                                                                         offset=qparams.query.pagination.skip,
-                                                                        limit=qparams.query.pagination.limit)
+                                                                        limit=qparams.query.pagination.limit,
+                                                                        extra_filters=genomics_filters)
         if count_ids == 0:
             return schema, count_ids, [], discovery_data
     else:

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -560,6 +560,7 @@ def discovery_query_primary_site(filter):
         {filter['exposures_filters']}
         {filter['treatments_filters']}
         {filter['datasets_discovery_filters']}
+        {filter['genomics_filters']}
         GROUP BY c.concept_name
     """
 
@@ -576,6 +577,7 @@ def discovery_query_treatment_type(filter):
         {filter['exposures_filters']}
         {filter['treatments_filters']}
         {filter['datasets_discovery_filters']}
+        {filter['genomics_filters']}
         GROUP BY c.concept_name
     """
 
@@ -592,6 +594,7 @@ def discovery_query_drug_type(filter):
         {filter['exposures_filters']}
         {filter['treatments_filters']}
         {filter['datasets_discovery_filters']}
+        {filter['genomics_filters']}
         GROUP BY c.concept_name
     """
 
@@ -607,6 +610,7 @@ def discovery_query_program(filter):
         {filter['exposures_filters']}
         {filter['treatments_filters']}
         {filter['datasets_discovery_filters']}
+        {filter['genomics_filters']}
         GROUP BY d.dataset_id
     """
 
@@ -621,6 +625,7 @@ def super_query_get(filter, offset, limit):
         {filter['exposures_filters']}
         {filter['treatments_filters']}
         {filter['datasets_filters']}
+        {filter['genomics_filters']}
 
         limit {limit}
         offset {offset}
@@ -763,9 +768,10 @@ async def filters(filtersDict, offset, limit, extra_filters):
 def search_genomic_variants(qparams: RequestParams=RequestParams()):
     # We basically need to form a request to HTSGet and pass all of our qparams.requestParameters.g_variant to them
     headers = {
-        "X-Service-Token": authx.auth.create_service_token()
+        "X-Service-Token": authx.auth.create_service_token(),
+        "Authorization": request.headers["Authorization"]
     }
-    logger.info(qparams.query.request_parameters)
+
     payload = {
         'query': {
             'requestParameters': qparams.query.request_parameters["g_variant"]
@@ -786,7 +792,7 @@ def search_genomic_variants(qparams: RequestParams=RequestParams()):
                 # How do we search on this in a performant manner...
                 # Scratch that, we only have a few days left to implement this
     else:
-        logger.error(f"Received error {response.status_code} while searching HTSGet: {response.reason}")
+        logger.error(f"Received error {response.status_code} while searching HTSGet: {response.reason} {response.text}")
     return found_samples
 
 
@@ -798,7 +804,9 @@ def create_samples_filter(samples: List, filters_dict: dict):
         if not first:
             ret_filter += ' or '
         first = False
-        ret_filter += f' CONCAT(dataset_id, ''~'', specimen_id) = :samples{i}'
+        #Son said it was dataset_id~specimen_id but it looks more like it's just sample_id
+        #ret_filter += f' CONCAT(dataset_id, ''~'', specimen_id) = :samples{i}'
+        ret_filter += f' sample_id = :samples{i}'
         filters_dict[f'samples{i}'] = sample_id
     # Close both the exists clause and also the chain of dataset_id conditionals
     ret_filter += '))'

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -753,7 +753,7 @@ async def checkFilters(filtersDict, offset, limit, extra_filters, extra_filters_
     discovery = await get_discovery(base_filter, filters_dict)
 
     query_get = super_query_get(base_filter, offset, limit)
-    logger.info(query_get)
+    # logger.info(query_get)
     records_get = await basic_query(query_get, filters_dict)
     listOfList = [str(record[0]) for record in records_get]
 
@@ -789,7 +789,7 @@ def search_genomic_variants(qparams: RequestParams=RequestParams()):
             if not isinstance(results, list):
                 continue
             for item in results:
-                found_samples.append(item["submitter_sample_id"])
+                found_samples.append(program + "~" + item["submitter_sample_id"])
                 # How do we search on this in a performant manner...
                 # Scratch that, we only have a few days left to implement this
     else:
@@ -805,8 +805,6 @@ def create_samples_filter(samples: List, filters_dict: dict):
         if not first:
             ret_filter += ' or '
         first = False
-        #Son said it was dataset_id~specimen_id but it looks more like it's just sample_id
-        #ret_filter += f' CONCAT(dataset_id, ''~'', specimen_id) = :samples{i}'
         ret_filter += f' sample_id = :samples{i}'
         filters_dict[f'samples{i}'] = sample_id
     # Close both the exists clause and also the chain of dataset_id conditionals

--- a/src/beacon/request/model.py
+++ b/src/beacon/request/model.py
@@ -118,6 +118,8 @@ class RequestParams(CamelModel):
                     self.query.filters.append(v)
                 elif k == "requestedGranularity":
                     self.query.requested_granularity = v
+                elif k == "requestParameters":
+                    self.query.request_parameters.update(v)
                 else:
                     self.query.request_parameters[k] = v
         return self


### PR DESCRIPTION
# Ticket(s)

- [DIG-2224](https://candig.atlassian.net/browse/DIG-2224)

# Description
This allows you to search on genomic fields as part of a search to the /individuals endpoint

# Related
https://github.com/CanDIG/candig-api/pull/55 should be merged first

# To test
- Make sure you're on the genomic ingest branch: https://github.com/CanDIG/CanDIGv3/pull/75
- Ingest test data via:
```
curl -X "POST" "http://candig.docker.internal:5080/candig-api/v1/datasets/upload/samples?site_id=SITE_PM2C" \
     -H 'Authorization: Bearer '$TOKEN \
     -H 'Content-Type: multipart/form-data; charset=utf-8;' \
     -F "file=@etc/tests/integration/input_mohccn_data.json"

curl -X "POST" "http://candig.docker.internal:5080/candig-api/v1/datasets/upload/genomic?site_id=SITE_PM2C" \
     -H 'Authorization: Bearer '$TOKEN \
     -H 'Content-Type: multipart/form-data; charset=utf-8;' \
     -F "file=@etc/tests/integration/small_dataset_genomic_ingest.json"
```

- Test a query via:
```
curl candig.docker.internal:5080/candig-api/v1/beacon/persons -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d '{"meta": {"apiVersion": "v2.0.0"}, "query": {"requestedGranularity": "record", "requestParameters": { "g_variant": { "gene_id": "LOC102723996" }}}}' | jq
```

## Types of Change(s)

- [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

If breaking, Which other services does it affect?

- [ ] authx
- [ ] data-portal
- [ ] ingest
- [ ] clinical ETL
- [ ] federation
- [ ] htsget-app
- [ ] katsu
- [ ] CanDIG OPA
- [ ] Query

<!--- If a breaking change, describe the impact the PR will have on the services selected above --->

## Has it been tested for:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] Prettier linter doesn't return errors
- [ ] Locally tested
  - [ ] using stable release
  - [ ] using develop branches
- [ ] Dev server tested
- [ ] Production tested when merging into stable/production branch


[DIG-2224]: https://candig.atlassian.net/browse/DIG-2224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ