### PR TITLE
DIG-2224: Variants search

### DIFF
--- a/beacon-schema.yml
+++ b/beacon-schema.yml
@@ -197,6 +197,7 @@ components:
               - $ref: '#/components/schemas/BeaconBooleanResponseBody'
               - $ref: '#/components/schemas/BeaconCountResponseBody'
               - $ref: '#/components/schemas/BeaconSearchResponseBody'
+              - $ref: '#/components/schemas/QuickSearchResult'
     BeaconErrorResponse:
       description: An unsuccessful operation.
       content:
@@ -285,19 +286,16 @@ components:
       description: Result with initial estimated data and a link to full Beacon result
       type: object
       properties:
-        beaconResultUrl:
-          type: string
         estimatedResults:
-          type: array
-          items:
-            type: object
-            properties:
-              analysisId:
-                type: string
-              programId:
-                type: string
-              variantCount:
-                type: integer
+          type: object
+        estimatedSearchParameters:
+          type: object
+        meta:
+          $ref: '#/components/schemas/BeaconResponseMeta'
+      required:
+        - estimatedResults
+        - estimatedSearchParameters
+        - meta
     BeaconConfigurationResponse:
       type: object
       description: >-

--- a/beacon-schema.yml
+++ b/beacon-schema.yml
@@ -951,8 +951,8 @@ components:
       required:
         - beaconId
         - apiVersion
-        - returnedSchemas
-        - returnedGranularity
+        # - returnedSchemas
+        # - returnedGranularity
         - receivedRequestSummary
       type: object
     BeaconId:
@@ -996,7 +996,7 @@ components:
       required:
         - apiVersion
         - requestedSchemas
-        - pagination
+        # - pagination
         - requestedGranularity
     BeaconResultsets:
       description: Sets of results to be returned as query response.

--- a/beacon-schema.yml
+++ b/beacon-schema.yml
@@ -129,6 +129,19 @@ paths:
                 $ref: '#/components/schemas/BeaconEntryTypesResponse'
         default:
           $ref: '#/components/responses/BeaconErrorResponse'
+  /g_variants:
+    post:
+      description: Search for variants
+      operationId: beacon_operations.variants_search
+      requestBody:
+        $ref: '#/components/requestBodies/BeaconRequestBody'
+      responses:
+        '200':
+          $ref: '#/components/responses/VariantsOKResponse'
+        default:
+          $ref: '#/components/responses/BeaconErrorResponse'
+      tags:
+        - POST Endpoints
 components:
   parameters:
     requestedSchema:
@@ -175,6 +188,15 @@ components:
               - $ref: '#/components/schemas/BeaconBooleanResponse'
               - $ref: '#/components/schemas/BeaconCountResponse'
               - $ref: '#/components/schemas/BeaconResultsetsResponse'
+    VariantsOKResponse:
+      description: Successful variant search operation.
+      content:
+        application/json:
+          schema:
+            anyOf:
+              - $ref: '#/components/schemas/BeaconBooleanResponseBody'
+              - $ref: '#/components/schemas/BeaconCountResponseBody'
+              - $ref: '#/components/schemas/BeaconSearchResponseBody'
     BeaconErrorResponse:
       description: An unsuccessful operation.
       content:
@@ -207,6 +229,75 @@ components:
             description: Response of a request for information about a Beacon
             $ref: '#/components/schemas/BeaconInfoResponse'
   schemas:
+    BeaconBooleanResponseBody:
+      description: Complete definition for a minimal response that provides *only* a `Boolean` exists true|false answer.
+      properties:
+        beaconHandovers:
+          $ref: '#/components/schemas/ListOfHandovers'
+        info:
+          $ref: '#/components/schemas/Info'
+        meta:
+          $ref: '#/components/schemas/BeaconResponseMeta'
+        responseSummary:
+          description: Boolean (true/false) response section.
+          properties:
+            exists:
+              $ref: '#/components/schemas/Exists'
+          required:
+            - exists
+          type: object
+      required:
+        - meta
+        - responseSummary
+      type: object
+    BeaconCountResponseBody:
+      description: Complete definition for a response that does not include record level details but provides `Boolean` and `count` information.
+      properties:
+        beaconHandovers:
+          $ref: '#/components/schemas/ListOfHandovers'
+        info:
+          $ref: '#/components/schemas/Info'
+        meta:
+          $ref: '#/components/schemas/BeaconResponseMeta'
+        responseSummary:
+          $ref: '#/components/schemas/BeaconCountResponseSection'
+      required:
+        - meta
+        - responseSummary
+      type: object
+    BeaconSearchResponseBody:
+      description: Beacon quick search result
+      properties:
+        info:
+          $ref: '#/components/schemas/Info'
+        meta:
+          $ref: '#/components/schemas/BeaconResponseMeta'
+        response:
+          $ref: '#/components/schemas/QuickSearchResult'
+        responseSummary:
+          $ref: '#/components/schemas/BeaconSummaryResponseSection'
+      required:
+        - meta
+        - responseSummary
+        - response
+      type: object
+    QuickSearchResult:
+      description: Result with initial estimated data and a link to full Beacon result
+      type: object
+      properties:
+        beaconResultUrl:
+          type: string
+        estimatedResults:
+          type: array
+          items:
+            type: object
+            properties:
+              analysisId:
+                type: string
+              programId:
+                type: string
+              variantCount:
+                type: integer
     BeaconConfigurationResponse:
       type: object
       description: >-

--- a/src/api/beacon_operations.py
+++ b/src/api/beacon_operations.py
@@ -1,7 +1,7 @@
 import connexion
 
 #from ..beacon.request.handlers import filtering_terms_handler
-from ..beacon.omop import datasets, filtering_terms, individuals
+from ..beacon.omop import datasets, filtering_terms, individuals, variants
 #from ..beacon.omop.schemas import DefaultSchemas
 from ..beacon.response import framework
 from ..beacon.request import RequestParams
@@ -116,4 +116,9 @@ async def post_person(body: dict):
     else:
         retval = build_beacon_boolean_response(records, count, params, lambda x, y: x, schema, discovery_data)
 
+    return retval, 200
+
+async def variants_search(body: dict):
+    params = RequestParams(**body).from_request(body)
+    retval = await variants.get_variants(params)
     return retval, 200

--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -8,6 +8,7 @@ from ...beacon.omop.utils import  search_ontologies, basic_query, peek
 from ...beacon.omop import engine, mappings
 from ...beacon.request.model import RequestParams
 from ...beacon.omop.schemas import DefaultSchemas
+from .utils import search_htsget, get_samples_from_htsget_response, create_samples_filter
 import aiosql
 from sqlalchemy import text, bindparam
 from ..conf import MAX_LIMIT
@@ -20,9 +21,6 @@ logger = CanDIGLogger(__file__)
 
 queries_file = Path(__file__).parent / "sql" / "individuals.sql"
 individual_queries = aiosql.from_path(queries_file, "psycopg2", mandatory_parameters=False)
-
-CANDIG_URL = os.getenv("CANDIG_URL", "")
-HTSGET_URL = os.getenv("HTSGET_URL", f"{CANDIG_URL}/genomics")
 
 def get_basic_discovery_response():
     return {
@@ -661,8 +659,7 @@ async def get_discovery(base_filter, filters_dict):
     discovery['drug_type_count'] = await format_filtered_discovery(discovery_query_drug_type(base_filter), filters_dict)
     return discovery
 
-async def checkFilters(filtersDict, offset, limit, extra_filters, extra_filters_dict):
-    listOfList = []
+async def parseFilters(filtersDict, extra_filters, extra_filters_dict):
     dictTableMap = []
     typeQuery = request.method
     async with engine.connect() as conn:
@@ -742,10 +739,15 @@ async def checkFilters(filtersDict, offset, limit, extra_filters, extra_filters_
                     # Look in which domains the concept_id belongs
                     tableMap = map_domains(domain_id)
                 dictTableMap.append([tableMap, listConcept_id, operator, value, includeDescendantTerms])
-    # logger.info(dictTableMap)
     base_filter, filters_dict = create_dynamic_filter(dictTableMap)
     base_filter.update(extra_filters)
     filters_dict.update(extra_filters_dict)
+    return base_filter, filters_dict
+
+async def checkFilters(filtersDict, offset, limit, extra_filters, extra_filters_dict):
+    base_filter, filters_dict = await parseFilters(filtersDict, extra_filters, extra_filters_dict)
+    
+    # logger.info(dictTableMap)
     query_count = super_query_count(base_filter)
     count_records = (await basic_query(query_count, filters_dict)).fetchone()[0]
 
@@ -765,53 +767,6 @@ async def filters(filtersDict, offset, limit, extra_filters, extra_filters_dict)
     return await checkFilters(filtersDict, offset, limit, extra_filters, extra_filters_dict)
 
 
-def search_genomic_variants(qparams: RequestParams=RequestParams()):
-    # We basically need to form a request to HTSGet and pass all of our qparams.requestParameters.g_variant to them
-    headers = {
-        "X-Service-Token": authx.auth.create_service_token(),
-        "Authorization": request.headers["Authorization"]
-    }
-
-    payload = {
-        'query': {
-            'requestParameters': qparams.query.request_parameters["g_variant"]
-        },
-        'meta': {
-            'apiVersion': 'v2'
-        }
-    }
-
-    response = requests.post(url=f"{HTSGET_URL}/beacon/v2/g_variants", headers=headers, json=payload)
-    found_samples = []
-    if response.ok:
-        htsget = response.json()
-        for program, results in htsget.get('estimatedResults', {}).items():
-            if not isinstance(results, list):
-                continue
-            for item in results:
-                found_samples.append(program + "~" + item["submitter_sample_id"])
-                # How do we search on this in a performant manner...
-                # Scratch that, we only have a few days left to implement this
-    else:
-        logger.error(f"Received error {response.status_code} while searching HTSGet: {response.reason} {response.text}")
-    return found_samples
-
-
-def create_samples_filter(samples: List, filters_dict: dict):
-    ret_filter = 'and exists (SELECT 1 FROM candig.sample d where p.person_id = d.person_id and ('
-    first = True
-    for i, sample_id in enumerate(samples):
-        # Expecting sample_id to be of the form: dataset_id~specimen_id e.g. SITE_PM2C~SAMPLE_0001
-        if not first:
-            ret_filter += ' or '
-        first = False
-        ret_filter += f' sample_id = :samples{i}'
-        filters_dict[f'samples{i}'] = sample_id
-    # Close both the exists clause and also the chain of dataset_id conditionals
-    ret_filter += '))'
-    return ret_filter, filters_dict
-
-
 async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=RequestParams()):
 
     schema = DefaultSchemas.INDIVIDUALS
@@ -822,7 +777,7 @@ async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=R
     extra_filters = {}
     extra_filters_dict = {}
     if "g_variant" in qparams.query.request_parameters:
-        found_samples = search_genomic_variants(qparams)
+        found_samples = get_samples_from_htsget_response(search_htsget(qparams))
 
         # If a genomic variant was requested but none was found, exit early
         if len(found_samples) == 0:

--- a/src/beacon/omop/utils.py
+++ b/src/beacon/omop/utils.py
@@ -1,16 +1,23 @@
-from typing import Dict
-
-from sqlalchemy import text
-from ...beacon.omop import engine
 import aiosql
 import itertools
+import os
+import requests
+from connexion import request
+from sqlalchemy import text
+from typing import List
 
+import authx.auth
+from ...beacon.omop import engine
+from ...beacon.request.model import RequestParams
 from candigv2_logging.logging import CanDIGLogger
 
 logger = CanDIGLogger(__file__)
 
 CDM_SCHEMA='cdm'
 VOCABULARIES_SCHEMA='vocabularies'
+
+CANDIG_URL = os.getenv("CANDIG_URL", "")
+HTSGET_URL = os.getenv("HTSGET_URL", f"{CANDIG_URL}/genomics")
 
 from pathlib import Path
 queries_file = Path(__file__).parent / "sql" / "individuals.sql"
@@ -141,3 +148,50 @@ async def get_documents(listVariables: list, query: str, skip: int, limit: int):
         recordsFinal = records.fetchmany(limit) # format_query(listVariables, records)
         # Switch the SQLAlchemy result to a dict for the response
         return [record._asdict() for record in recordsFinal]
+
+def search_htsget(qparams: RequestParams=RequestParams()):
+    # We basically need to form a request to HTSGet and pass all of our qparams.requestParameters.g_variant to them
+    headers = {
+        "X-Service-Token": authx.auth.create_service_token(),
+        "Authorization": request.headers["Authorization"]
+    }
+
+    payload = {
+        'query': {
+            'requestParameters': qparams.query.request_parameters["g_variant"]
+        },
+        'meta': {
+            'apiVersion': 'v2'
+        }
+    }
+
+    response = requests.post(url=f"{HTSGET_URL}/beacon/v2/g_variants", headers=headers, json=payload)
+    if not response.ok:
+        logger.error(f"Received error {response.status_code} while searching HTSGet: {response.reason} {response.text}")
+    return response.json()
+
+
+def get_samples_from_htsget_response(htsget: dict):
+    found_samples = []
+    for program, results in htsget.get('estimatedResults', {}).items():
+        if not isinstance(results, list):
+            continue
+        for item in results:
+            found_samples.append(program + "~" + item["submitter_sample_id"])
+    return found_samples
+
+
+def create_samples_filter(samples: List, filters_dict: dict):
+    ret_filter = 'and exists (SELECT 1 FROM candig.sample d where p.person_id = d.person_id and ('
+    first = True
+    for i, sample_id in enumerate(samples):
+        # Expecting sample_id to be of the form: dataset_id~specimen_id e.g. SITE_PM2C~SAMPLE_0001
+        if not first:
+            ret_filter += ' or '
+        first = False
+        ret_filter += f' sample_id = :samples{i}'
+        filters_dict[f'samples{i}'] = sample_id
+    # Close both the exists clause and also the chain of dataset_id conditionals
+    ret_filter += '))'
+    return ret_filter, filters_dict
+

--- a/src/beacon/omop/variants.py
+++ b/src/beacon/omop/variants.py
@@ -23,10 +23,10 @@ CANDIG_URL = os.getenv("CANDIG_URL", "")
 HTSGET_URL = os.getenv("HTSGET_URL", f"{CANDIG_URL}/genomics")
 
 
-def create_sample_query(filter, offset, limit):
+def create_sample_query(filter):
     return  f""" select d.sample_id
         from omop.person p
-        left join candig.sample d
+        left join candig.sample d ON p.person_id = d.person_id
         where true
         {filter['demographic_filters']}
         {filter['condition_filters']}
@@ -81,15 +81,15 @@ async def get_variants(qparams: dict):
         if not isinstance(results, list):
             continue
         items_to_remove = []
-        for index, item in enumerate(results):
+        for item in results:
             if f"{program}~{item['submitter_sample_id']}" not in found_samples:
-                items_to_remove.append(index)
+                items_to_remove.append(item)
         for item in items_to_remove:
-            results.pop(index)
+            results.remove(item)
         if len(results) == 0:
             programs_to_remove.append(program)
     for program in programs_to_remove:
-        htsget['estimatedResults'].remove(program)
+        del htsget['estimatedResults'][program]
 
     # Return the HTSGet
     return htsget

--- a/src/beacon/omop/variants.py
+++ b/src/beacon/omop/variants.py
@@ -1,0 +1,95 @@
+import os
+import re
+import requests
+
+from connexion import request
+from typing import Optional, List
+from ...beacon.omop.utils import  basic_query
+from .individuals import parseFilters
+from .utils import search_htsget, get_samples_from_htsget_response, create_samples_filter
+import aiosql
+from sqlalchemy import text, bindparam
+from ..conf import MAX_LIMIT
+
+from pathlib import Path
+from candigv2_logging.logging import CanDIGLogger
+
+logger = CanDIGLogger(__file__)
+
+queries_file = Path(__file__).parent / "sql" / "individuals.sql"
+individual_queries = aiosql.from_path(queries_file, "psycopg2", mandatory_parameters=False)
+
+CANDIG_URL = os.getenv("CANDIG_URL", "")
+HTSGET_URL = os.getenv("HTSGET_URL", f"{CANDIG_URL}/genomics")
+
+
+def create_sample_query(filter, offset, limit):
+    return  f""" select d.sample_id
+        from omop.person p
+        left join candig.sample d
+        where true
+        {filter['demographic_filters']}
+        {filter['condition_filters']}
+        {filter['measurement_filters']}
+        {filter['procedures_filters']}
+        {filter['exposures_filters']}
+        {filter['treatments_filters']}
+        {filter['datasets_filters']}
+        {filter['genomics_filters']}
+    """
+
+
+async def get_variants(qparams: dict):
+    # Pass the g_variants part of the request off to HTSGet
+    htsget = search_htsget(qparams)
+
+    # If there are no clinical filters, we can just return the HTSGet response here
+    filter_params = []
+    if qparams.query.filters and len(qparams.query.filters) > 0 and len(qparams.query.filters[0]) > 0:
+        filter_params = qparams.query.filters[0]
+    if len(filter_params) == 0:
+        return htsget
+
+    # Obtain all genomic samples hit
+    samples = get_samples_from_htsget_response(htsget)
+
+    # If there's no samples hit, return early
+    if len(samples) == 0:
+        return htsget
+
+    # Create a genomic filter with a bunch of entries
+    genomics_filters, genomic_filters_dict = create_samples_filter(samples, {})
+    extra_filters = {}
+    extra_filters['genomics_filters'] = genomics_filters
+
+    # Perform a clinical search via the code we have in individuals
+    base_filter, filters_dict = await parseFilters(filter_params,
+                                                    extra_filters=extra_filters,
+                                                    extra_filters_dict=genomic_filters_dict)
+    query_get = create_sample_query(base_filter)
+    records_get = await basic_query(query_get, filters_dict)
+
+    # Cut down the genomic samples to whatever samples remain in the individuals search
+    # Convert the list into a dict for faster lookup O(1) instead of O(n)
+    found_samples = {}
+    for record in records_get:
+        found_samples[str(record[0])] = True
+    
+    # Remove all entries whose dataset_id~submitter_sample_id does not exist in found_samples
+    programs_to_remove = []
+    for program, results in htsget.get('estimatedResults', {}).items():
+        if not isinstance(results, list):
+            continue
+        items_to_remove = []
+        for index, item in enumerate(results):
+            if f"{program}~{item['submitter_sample_id']}" not in found_samples:
+                items_to_remove.append(index)
+        for item in items_to_remove:
+            results.pop(index)
+        if len(results) == 0:
+            programs_to_remove.append(program)
+    for program in programs_to_remove:
+        htsget['estimatedResults'].remove(program)
+
+    # Return the HTSGet
+    return htsget


### PR DESCRIPTION
# Ticket(s)

- [DIG-2224](https://candig.atlassian.net/browse/DIG-2224)

# Description
Allows users to do a quick HTSGet search including clinical data

# Related
- #56 

# To test
1. Ingest data as in #56 
2. Search with just the gene name specified:
```
curl candig.docker.internal:5080/candig-api/v1/beacon/g_variants -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d '{"meta": {"apiVersion": "v2.0.0"}, "query": {"requestedGranularity": "record", "requestParameters": { "g_variant": { "gene_id": "LOC102723996" }}}}'
```
3. Search with both gene name and some clinical filtering:
```
curl candig.docker.internal:5080/candig-api/v1/beacon/g_variants -H "Content-Type: application/json" -H "Authorization: Bearer $TOKEN" -d '{"meta": {"apiVersion": "v2.0.0"}, "query": {"requestedGranularity": "record", "filters": [{ "id": "SNOMED:33821000087103" }], "requestParameters": { "g_variant": { "gene_id": "LOC102723996" }}}}'
```

## Types of Change(s)

- [ ] 🪲 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

If breaking, Which other services does it affect?

- [ ] authx
- [ ] data-portal
- [ ] ingest
- [ ] clinical ETL
- [ ] federation
- [ ] htsget-app
- [ ] katsu
- [ ] CanDIG OPA
- [ ] Query

<!--- If a breaking change, describe the impact the PR will have on the services selected above --->

## Has it been tested for:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] Prettier linter doesn't return errors
- [ ] Locally tested
  - [ ] using stable release
  - [ ] using develop branches
- [ ] Dev server tested
- [ ] Production tested when merging into stable/production branch


[DIG-2224]: https://candig.atlassian.net/browse/DIG-2224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ