### PR TITLE
Fixup discovery queries when doing searches with variants

### DIFF
--- a/src/beacon/omop/individuals.py
+++ b/src/beacon/omop/individuals.py
@@ -301,7 +301,8 @@ def create_dynamic_filter(filters):
         'procedures_filters': '',
         'exposures_filters': '',
         'treatments_filters': '',
-        'genomics_filters': ''  # Not filled out here
+        'genomics_filters': '',  # Not filled out here
+        'genomics_discovery_filters': '' # Not filled out here
     }
     filters_dict = {}
     request_datasets = []
@@ -558,7 +559,7 @@ def discovery_query_primary_site(filter):
         {filter['exposures_filters']}
         {filter['treatments_filters']}
         {filter['datasets_discovery_filters']}
-        {filter['genomics_filters']}
+        {filter['genomics_discovery_filters']}
         GROUP BY c.concept_name
     """
 
@@ -575,7 +576,7 @@ def discovery_query_treatment_type(filter):
         {filter['exposures_filters']}
         {filter['treatments_filters']}
         {filter['datasets_discovery_filters']}
-        {filter['genomics_filters']}
+        {filter['genomics_discovery_filters']}
         GROUP BY c.concept_name
     """
 
@@ -592,7 +593,7 @@ def discovery_query_drug_type(filter):
         {filter['exposures_filters']}
         {filter['treatments_filters']}
         {filter['datasets_discovery_filters']}
-        {filter['genomics_filters']}
+        {filter['genomics_discovery_filters']}
         GROUP BY c.concept_name
     """
 
@@ -608,7 +609,7 @@ def discovery_query_program(filter):
         {filter['exposures_filters']}
         {filter['treatments_filters']}
         {filter['datasets_discovery_filters']}
-        {filter['genomics_filters']}
+        {filter['genomics_discovery_filters']}
         GROUP BY d.dataset_id
     """
 
@@ -779,13 +780,13 @@ async def get_individuals(entry_id: Optional[str]=None, qparams: RequestParams=R
     if "g_variant" in qparams.query.request_parameters:
         found_samples = get_samples_from_htsget_response(search_htsget(qparams))
 
-        # If a genomic variant was requested but none was found, exit early
-        if len(found_samples) == 0:
-            return schema, 0, [], {}
-
-        # Otherwise, insert this as a single filter with a bunch of entries
+        # If a genomic variant was requested but none was found, we cannot exit early
+        # because the discovery counts will be wrong
         genomics_filters, genomic_filters_dict = create_samples_filter(found_samples, {})
         extra_filters['genomics_filters'] = genomics_filters
+        discovery_samples = get_samples_from_htsget_response(search_htsget(qparams, useAdminAuth=True))
+        discovery_filters, genomic_filters_dict = create_samples_filter(discovery_samples, genomic_filters_dict)
+        extra_filters['genomics_discovery_filters'] = discovery_filters
         extra_filters_dict.update(genomic_filters_dict)
 
     if qparams.query.pagination.limit == 0:

--- a/src/beacon/omop/utils.py
+++ b/src/beacon/omop/utils.py
@@ -149,12 +149,14 @@ async def get_documents(listVariables: list, query: str, skip: int, limit: int):
         # Switch the SQLAlchemy result to a dict for the response
         return [record._asdict() for record in recordsFinal]
 
-def search_htsget(qparams: RequestParams=RequestParams()):
+def search_htsget(qparams: RequestParams=RequestParams(), useAdminAuth: bool = False):
     # We basically need to form a request to HTSGet and pass all of our qparams.requestParameters.g_variant to them
     headers = {
-        "X-Service-Token": authx.auth.create_service_token(),
         "Authorization": request.headers["Authorization"]
     }
+
+    if useAdminAuth:
+        headers["X-Service-Token"] = authx.auth.create_service_token()
 
     payload = {
         'query': {
@@ -182,6 +184,9 @@ def get_samples_from_htsget_response(htsget: dict):
 
 
 def create_samples_filter(samples: List, filters_dict: dict):
+    # If there are no valid samples to match on, return nothing
+    if len(samples) == 0:
+        return 'and false', filters_dict
     ret_filter = 'and exists (SELECT 1 FROM candig.sample d where p.person_id = d.person_id and ('
     first = True
     for i, sample_id in enumerate(samples):


### PR DESCRIPTION
# Description
Fix the discovery queries erroring out when doing searches with variants

# To test
Discovery tests in https://github.com/CanDIG/CanDIGv3/pull/80 should pass with this

## Types of Change(s)

- [x] 🪲 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)

If breaking, Which other services does it affect?

- [ ] authx
- [ ] data-portal
- [ ] ingest
- [ ] clinical ETL
- [ ] federation
- [x] htsget-app
- [ ] katsu
- [ ] CanDIG OPA
- [ ] Query

<!--- If a breaking change, describe the impact the PR will have on the services selected above --->

## Has it been tested for:

- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] Prettier linter doesn't return errors
- [ ] Locally tested
  - [ ] using stable release
  - [ ] using develop branches
- [ ] Dev server tested
- [ ] Production tested when merging into stable/production branch
